### PR TITLE
Initial Pandas-based importer

### DIFF
--- a/ferry/database/__init__.py
+++ b/ferry/database/__init__.py
@@ -1,6 +1,11 @@
+from sqlalchemy import MetaData, Table
+from sqlalchemy.inspection import inspect
+from sqlalchemy.ext.declarative import declarative_base
+
 from ferry.database.database import Engine, Session
 from ferry.database.database_utilities import *
 from ferry.database.models import (
+    Base,
     Course,
     DemandStatistics,
     EvaluationNarrative,

--- a/ferry/database/__init__.py
+++ b/ferry/database/__init__.py
@@ -1,6 +1,6 @@
 from sqlalchemy import MetaData, Table
-from sqlalchemy.inspection import inspect
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.inspection import inspect
 
 from ferry.database.database import Engine, Session
 from ferry.database.database_utilities import *

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -57,10 +57,13 @@ class Course(BaseModel):
         index=True,
         nullable=False,
     )
-    season = relationship("Season", backref="courses")
+    season = relationship("Season", backref="courses", cascade="all")
 
     professors = relationship(
-        "Professor", secondary=course_professors, back_populates="courses"
+        "Professor",
+        secondary=course_professors,
+        back_populates="courses",
+        cascade="all",
     )
 
     areas = Column(JSON, comment="Course areas (humanities, social sciences, sciences)")
@@ -88,8 +91,7 @@ class Course(BaseModel):
         comment='Course times and locations, displayed in the "Meets" row in CourseTable course modals',
     )
     times_summary = Column(
-        String,
-        comment='Course times, displayed in the "Times" column in CourseTable',
+        String, comment='Course times, displayed in the "Times" column in CourseTable',
     )
     times_by_day = Column(
         JSON,
@@ -127,7 +129,7 @@ class Listing(BaseModel):
         index=True,
         nullable=False,
     )
-    course = relationship("Course", backref="listings")
+    course = relationship("Course", backref="listings", cascade="all")
 
     subject = Column(
         String,
@@ -140,9 +142,7 @@ class Listing(BaseModel):
         nullable=False,
     )
     course_code = Column(
-        String,
-        comment='[computed] subject + number (e.g. "AMST 312")',
-        index=True,
+        String, comment='[computed] subject + number (e.g. "AMST 312")', index=True,
     )
     section = Column(
         String,
@@ -156,7 +156,7 @@ class Listing(BaseModel):
         index=True,
         nullable=False,
     )
-    season = relationship("Season", backref="listings")
+    season = relationship("Season", backref="listings", cascade="all")
     crn = Column(
         Integer,
         comment="The CRN associated with this listing",
@@ -187,20 +187,11 @@ class DemandStatistics(BaseModel):
         primary_key=True,
         comment="The course to which these demand statistics apply",
     )
-    latest_demand = Column(
-        Integer,
-        comment="Latest demand count",
-    )
-    latest_demand_date = Column(
-        String,
-        comment="Latest demand date",
-    )
-    course = relationship("Course", backref="demand_statistics")
+    latest_demand = Column(Integer, comment="Latest demand count",)
+    latest_demand_date = Column(String, comment="Latest demand date",)
+    course = relationship("Course", backref="demand_statistics", cascade="all")
 
-    demand = Column(
-        JSON,
-        comment="JSON dict containing demand stats by day",
-    )
+    demand = Column(JSON, comment="JSON dict containing demand stats by day",)
 
 
 class Professor(BaseModel):
@@ -208,11 +199,14 @@ class Professor(BaseModel):
 
     professor_id = Column(Integer, comment="Professor ID", primary_key=True)
     name = Column(String, comment="Name of the professor", index=True, nullable=False)
-    email = Column(String, comment="Email address of the professor", nullable=False)
-    ocs_id = Column(String, comment="Professor ID used by Yale OCS", nullable=False)
+    email = Column(String, comment="Email address of the professor", nullable=True)
+    ocs_id = Column(String, comment="Professor ID used by Yale OCS", nullable=True)
 
     courses = relationship(
-        "Course", secondary=course_professors, back_populates="professors"
+        "Course",
+        secondary=course_professors,
+        back_populates="professors",
+        cascade="all",
     )
 
     average_rating = Column(
@@ -232,7 +226,9 @@ class EvaluationStatistics(BaseModel):
         index=True,
         nullable=False,
     )
-    course = relationship("Course", backref=backref("statistics", uselist=False))
+    course = relationship(
+        "Course", backref=backref("statistics", uselist=False), cascade="all",
+    )
 
     enrolled = Column(Integer, comment="Number of students enrolled in course")
     responses = Column(Integer, comment="Number of responses")
@@ -249,18 +245,13 @@ class EvaluationQuestion(BaseModel):
     __tablename__ = "evaluation_questions"
 
     question_code = Column(
-        String,
-        comment='Question code from OCE (e.g. "YC402")',
-        primary_key=True,
+        String, comment='Question code from OCE (e.g. "YC402")', primary_key=True,
     )
     is_narrative = Column(
         Boolean,
         comment="True if the question has narrative responses. False if the question has categorica/numerical responses",
     )
-    question_text = Column(
-        String,
-        comment="The question text",
-    )
+    question_text = Column(String, comment="The question text",)
     options = Column(
         JSON,
         comment="JSON array of possible responses (only if the question is not a narrative",
@@ -284,7 +275,7 @@ class EvaluationNarrative(BaseModel):
         index=True,
         nullable=False,
     )
-    course = relationship("Course", backref="evaluation_narratives")
+    course = relationship("Course", backref="evaluation_narratives", cascade="all")
     question_code = Column(
         String,
         ForeignKey("evaluation_questions.question_code"),
@@ -292,12 +283,11 @@ class EvaluationNarrative(BaseModel):
         index=True,
         nullable=False,
     )
-    question = relationship("EvaluationQuestion", backref="evaluation_narratives")
-
-    comment = Column(
-        String,
-        comment="Response to the question",
+    question = relationship(
+        "EvaluationQuestion", backref="evaluation_narratives", cascade="all",
     )
+
+    comment = Column(String, comment="Response to the question",)
 
 
 class EvaluationRating(BaseModel):
@@ -312,7 +302,7 @@ class EvaluationRating(BaseModel):
         index=True,
         nullable=False,
     )
-    course = relationship("Course", backref="evaluation_ratings")
+    course = relationship("Course", backref="evaluation_ratings", cascade="all")
     question_code = Column(
         String,
         ForeignKey("evaluation_questions.question_code"),
@@ -320,9 +310,8 @@ class EvaluationRating(BaseModel):
         index=True,
         nullable=False,
     )
-    question = relationship("EvaluationQuestion", backref="evaluation_ratings")
-
-    rating = Column(
-        JSON,
-        comment="JSON array of the response counts for each option",
+    question = relationship(
+        "EvaluationQuestion", backref="evaluation_ratings", cascade="all"
     )
+
+    rating = Column(JSON, comment="JSON array of the response counts for each option",)

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -88,7 +88,8 @@ class Course(BaseModel):
         comment='Course times and locations, displayed in the "Meets" row in CourseTable course modals',
     )
     times_summary = Column(
-        String, comment='Course times, displayed in the "Times" column in CourseTable',
+        String,
+        comment='Course times, displayed in the "Times" column in CourseTable',
     )
     times_by_day = Column(
         JSON,
@@ -139,7 +140,9 @@ class Listing(BaseModel):
         nullable=False,
     )
     course_code = Column(
-        String, comment='[computed] subject + number (e.g. "AMST 312")', index=True,
+        String,
+        comment='[computed] subject + number (e.g. "AMST 312")',
+        index=True,
     )
     section = Column(
         String,
@@ -184,11 +187,20 @@ class DemandStatistics(BaseModel):
         primary_key=True,
         comment="The course to which these demand statistics apply",
     )
-    latest_demand = Column(Integer, comment="Latest demand count",)
-    latest_demand_date = Column(String, comment="Latest demand date",)
+    latest_demand = Column(
+        Integer,
+        comment="Latest demand count",
+    )
+    latest_demand_date = Column(
+        String,
+        comment="Latest demand date",
+    )
     course = relationship("Course", backref="demand_statistics")
 
-    demand = Column(JSON, comment="JSON dict containing demand stats by day",)
+    demand = Column(
+        JSON,
+        comment="JSON dict containing demand stats by day",
+    )
 
 
 class Professor(BaseModel):
@@ -237,13 +249,18 @@ class EvaluationQuestion(BaseModel):
     __tablename__ = "evaluation_questions"
 
     question_code = Column(
-        String, comment='Question code from OCE (e.g. "YC402")', primary_key=True,
+        String,
+        comment='Question code from OCE (e.g. "YC402")',
+        primary_key=True,
     )
     is_narrative = Column(
         Boolean,
         comment="True if the question has narrative responses. False if the question has categorica/numerical responses",
     )
-    question_text = Column(String, comment="The question text",)
+    question_text = Column(
+        String,
+        comment="The question text",
+    )
     options = Column(
         JSON,
         comment="JSON array of possible responses (only if the question is not a narrative",
@@ -277,7 +294,10 @@ class EvaluationNarrative(BaseModel):
     )
     question = relationship("EvaluationQuestion", backref="evaluation_narratives")
 
-    comment = Column(String, comment="Response to the question",)
+    comment = Column(
+        String,
+        comment="Response to the question",
+    )
 
 
 class EvaluationRating(BaseModel):
@@ -302,4 +322,7 @@ class EvaluationRating(BaseModel):
     )
     question = relationship("EvaluationQuestion", backref="evaluation_ratings")
 
-    rating = Column(JSON, comment="JSON array of the response counts for each option",)
+    rating = Column(
+        JSON,
+        comment="JSON array of the response counts for each option",
+    )

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -91,7 +91,8 @@ class Course(BaseModel):
         comment='Course times and locations, displayed in the "Meets" row in CourseTable course modals',
     )
     times_summary = Column(
-        String, comment='Course times, displayed in the "Times" column in CourseTable',
+        String,
+        comment='Course times, displayed in the "Times" column in CourseTable',
     )
     times_by_day = Column(
         JSON,
@@ -142,7 +143,9 @@ class Listing(BaseModel):
         nullable=False,
     )
     course_code = Column(
-        String, comment='[computed] subject + number (e.g. "AMST 312")', index=True,
+        String,
+        comment='[computed] subject + number (e.g. "AMST 312")',
+        index=True,
     )
     section = Column(
         String,
@@ -187,11 +190,20 @@ class DemandStatistics(BaseModel):
         primary_key=True,
         comment="The course to which these demand statistics apply",
     )
-    latest_demand = Column(Integer, comment="Latest demand count",)
-    latest_demand_date = Column(String, comment="Latest demand date",)
+    latest_demand = Column(
+        Integer,
+        comment="Latest demand count",
+    )
+    latest_demand_date = Column(
+        String,
+        comment="Latest demand date",
+    )
     course = relationship("Course", backref="demand_statistics", cascade="all")
 
-    demand = Column(JSON, comment="JSON dict containing demand stats by day",)
+    demand = Column(
+        JSON,
+        comment="JSON dict containing demand stats by day",
+    )
 
 
 class Professor(BaseModel):
@@ -227,7 +239,9 @@ class EvaluationStatistics(BaseModel):
         nullable=False,
     )
     course = relationship(
-        "Course", backref=backref("statistics", uselist=False), cascade="all",
+        "Course",
+        backref=backref("statistics", uselist=False),
+        cascade="all",
     )
 
     enrolled = Column(Integer, comment="Number of students enrolled in course")
@@ -245,13 +259,18 @@ class EvaluationQuestion(BaseModel):
     __tablename__ = "evaluation_questions"
 
     question_code = Column(
-        String, comment='Question code from OCE (e.g. "YC402")', primary_key=True,
+        String,
+        comment='Question code from OCE (e.g. "YC402")',
+        primary_key=True,
     )
     is_narrative = Column(
         Boolean,
         comment="True if the question has narrative responses. False if the question has categorica/numerical responses",
     )
-    question_text = Column(String, comment="The question text",)
+    question_text = Column(
+        String,
+        comment="The question text",
+    )
     options = Column(
         JSON,
         comment="JSON array of possible responses (only if the question is not a narrative",
@@ -284,10 +303,15 @@ class EvaluationNarrative(BaseModel):
         nullable=False,
     )
     question = relationship(
-        "EvaluationQuestion", backref="evaluation_narratives", cascade="all",
+        "EvaluationQuestion",
+        backref="evaluation_narratives",
+        cascade="all",
     )
 
-    comment = Column(String, comment="Response to the question",)
+    comment = Column(
+        String,
+        comment="Response to the question",
+    )
 
 
 class EvaluationRating(BaseModel):
@@ -314,4 +338,7 @@ class EvaluationRating(BaseModel):
         "EvaluationQuestion", backref="evaluation_ratings", cascade="all"
     )
 
-    rating = Column(JSON, comment="JSON array of the response counts for each option",)
+    rating = Column(
+        JSON,
+        comment="JSON array of the response counts for each option",
+    )

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -88,8 +88,7 @@ class Course(BaseModel):
         comment='Course times and locations, displayed in the "Meets" row in CourseTable course modals',
     )
     times_summary = Column(
-        String,
-        comment='Course times, displayed in the "Times" column in CourseTable',
+        String, comment='Course times, displayed in the "Times" column in CourseTable',
     )
     times_by_day = Column(
         JSON,
@@ -140,9 +139,7 @@ class Listing(BaseModel):
         nullable=False,
     )
     course_code = Column(
-        String,
-        comment='[computed] subject + number (e.g. "AMST 312")',
-        index=True,
+        String, comment='[computed] subject + number (e.g. "AMST 312")', index=True,
     )
     section = Column(
         String,
@@ -187,20 +184,11 @@ class DemandStatistics(BaseModel):
         primary_key=True,
         comment="The course to which these demand statistics apply",
     )
-    latest_demand = Column(
-        Integer,
-        comment="Latest demand count",
-    )
-    latest_demand_date = Column(
-        String,
-        comment="Latest demand date",
-    )
+    latest_demand = Column(Integer, comment="Latest demand count",)
+    latest_demand_date = Column(String, comment="Latest demand date",)
     course = relationship("Course", backref="demand_statistics")
 
-    demand = Column(
-        JSON,
-        comment="JSON dict containing demand stats by day",
-    )
+    demand = Column(JSON, comment="JSON dict containing demand stats by day",)
 
 
 class Professor(BaseModel):
@@ -234,11 +222,12 @@ class EvaluationStatistics(BaseModel):
     )
     course = relationship("Course", backref=backref("statistics", uselist=False))
 
-    enrollment = Column(
-        JSON, comment="a JSON dictionary with information about the course's enrollment"
-    )
+    enrolled = Column(Integer, comment="Number of students enrolled in course")
+    responses = Column(Integer, comment="Number of responses")
+    declined = Column(Integer, comment="Number of students who declined to respond")
+    no_response = Column(Integer, comment="Number of students who did not respond")
     extras = Column(
-        JSON, comment="arbitrary additional information attached to an evaluation"
+        JSON, comment="Arbitrary additional information attached to an evaluation"
     )
     avg_rating = Column(Float, comment="[computed] Average overall rating")
     avg_workload = Column(Float, comment="[computed] Average workload rating")
@@ -248,18 +237,13 @@ class EvaluationQuestion(BaseModel):
     __tablename__ = "evaluation_questions"
 
     question_code = Column(
-        String,
-        comment='Question code from OCE (e.g. "YC402")',
-        primary_key=True,
+        String, comment='Question code from OCE (e.g. "YC402")', primary_key=True,
     )
     is_narrative = Column(
         Boolean,
         comment="True if the question has narrative responses. False if the question has categorica/numerical responses",
     )
-    question_text = Column(
-        String,
-        comment="The question text",
-    )
+    question_text = Column(String, comment="The question text",)
     options = Column(
         JSON,
         comment="JSON array of possible responses (only if the question is not a narrative",
@@ -293,10 +277,7 @@ class EvaluationNarrative(BaseModel):
     )
     question = relationship("EvaluationQuestion", backref="evaluation_narratives")
 
-    comment = Column(
-        String,
-        comment="Response to the question",
-    )
+    comment = Column(String, comment="Response to the question",)
 
 
 class EvaluationRating(BaseModel):
@@ -321,7 +302,4 @@ class EvaluationRating(BaseModel):
     )
     question = relationship("EvaluationQuestion", backref="evaluation_ratings")
 
-    rating = Column(
-        JSON,
-        comment="JSON array of the response counts for each option",
-    )
+    rating = Column(JSON, comment="JSON array of the response counts for each option",)

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -26,7 +26,7 @@ class BaseModel(Base, SerializeMixin, ReprMixin):
 class Season(BaseModel):
     __tablename__ = "seasons"
     season_code = Column(
-        String(10), primary_key=True, comment="Season code (e.g. '202001')"
+        String(10), primary_key=True, comment="Season code (e.g. '202001')", index=True
     )
 
     term = Column(
@@ -41,14 +41,14 @@ class Season(BaseModel):
 course_professors = Table(
     "course_professors",
     Base.metadata,
-    Column("course_id", ForeignKey("courses.course_id"), primary_key=True),
-    Column("professor_id", ForeignKey("professors.professor_id"), primary_key=True),
+    Column("course_id", ForeignKey("courses.course_id"), primary_key=True, index=True),
+    Column("professor_id", ForeignKey("professors.professor_id"), primary_key=True, index=True),
 )
 
 
 class Course(BaseModel):
     __tablename__ = "courses"
-    course_id = Column(Integer, primary_key=True)
+    course_id = Column(Integer, primary_key=True, index=True)
 
     season_code = Column(
         String(10),
@@ -188,6 +188,7 @@ class DemandStatistics(BaseModel):
         Integer,
         ForeignKey("courses.course_id"),
         primary_key=True,
+        index=True,
         comment="The course to which these demand statistics apply",
     )
     latest_demand = Column(
@@ -262,6 +263,7 @@ class EvaluationQuestion(BaseModel):
         String,
         comment='Question code from OCE (e.g. "YC402")',
         primary_key=True,
+        index=True
     )
     is_narrative = Column(
         Boolean,

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -42,7 +42,12 @@ course_professors = Table(
     "course_professors",
     Base.metadata,
     Column("course_id", ForeignKey("courses.course_id"), primary_key=True, index=True),
-    Column("professor_id", ForeignKey("professors.professor_id"), primary_key=True, index=True),
+    Column(
+        "professor_id",
+        ForeignKey("professors.professor_id"),
+        primary_key=True,
+        index=True,
+    ),
 )
 
 
@@ -263,7 +268,7 @@ class EvaluationQuestion(BaseModel):
         String,
         comment='Question code from OCE (e.g. "YC402")',
         primary_key=True,
-        index=True
+        index=True,
     )
     is_narrative = Column(
         Boolean,

--- a/ferry/deploy_pandas.py
+++ b/ferry/deploy_pandas.py
@@ -1,0 +1,254 @@
+import argparse
+import collections
+import csv
+from typing import List
+
+import sqlalchemy
+from sqlalchemy import MetaData, schema
+from sqlalchemy.sql.schema import ForeignKeyConstraint
+
+from ferry import config, database
+from ferry.includes.tqdm import tqdm
+
+"""
+This script checks the database invariants.
+"""
+
+def listing_invariants(session):
+    """
+    Check invariant: listing.season_code == course.season_code if listing.course_id == course.course_id.
+    """
+    for listing_id, course_id, listing_season_code, course_season_code in session.query(
+        database.Listing.listing_id,
+        database.Listing.course_id,
+        database.Listing.season_code,
+        database.Course.season_code,
+    ).filter(database.Listing.course_id == database.Course.course_id):
+        if listing_season_code != course_season_code:
+            raise database.InvariantError(
+                f"listing {listing_id} has mismatched season_code with course {course_id}"
+            )
+
+
+def question_invariants(session):
+    """
+    Check invariant: evaluation_questions.options is null iff evaluation_questions.is_narrative = True
+    """
+    for question in session.query(
+        database.EvaluationQuestion
+    ):  # type: database.EvaluationQuestion
+        narrative = question.is_narrative
+        options = bool(question.options)
+        if narrative and options:
+            raise database.InvariantError(f"narrative question {question} has options")
+        if not narrative and not options:
+            raise database.InvariantError(f"ratings question {question} lacks options")
+
+
+def question_tag_invariant(session):
+    """
+    Check invariant: all questions sharing a tag also share is_narrative and len(options)
+    """
+    # Dictionary of question_code -> (is_narrative, len(options))
+    tag_cache = {}
+
+    def optlen(l):
+        return len(l) if l else -1
+
+    for question in session.query(
+        database.EvaluationQuestion
+    ):  # type: database.EvaluationQuestion
+        if not question.tag:
+            continue
+
+        if question.tag not in tag_cache:
+            tag_cache[question.tag] = (question.is_narrative, optlen(question.options))
+        else:
+            narrative, count = tag_cache[question.tag]
+            if question.is_narrative != narrative or count != optlen(question.options):
+                raise database.InvariantError(f"mismatched tag {question.tag}")
+
+
+
+def course_invariants(session):
+    """
+    Invariant: every course should have at least one listing.
+    """
+    courses_no_listings = (
+        session.query(database.Course)
+        .select_from(database.Listing)
+        .join(database.Listing.course, isouter=True)
+        .group_by(database.Course.course_id)
+        .having(sqlalchemy.func.count(database.Listing.listing_id) == 0)
+    ).all()
+
+    if courses_no_listings:
+        raise database.InvariantError(
+            f"the following courses have no listings: {', '.join(str(course) for course in courses_no_listings)}"
+        )
+
+def search_setup(session):
+    """
+    Setup materialized view and search function
+    """
+
+    with open(f"{config.RESOURCE_DIR}/search.sql") as f:
+        sql = f.read()
+    session.execute(sql)
+
+
+if __name__ == "__main__":
+    all_items = [
+        listing_invariants,
+        course_invariants,
+        question_invariants,
+        question_tag_invariant,
+    ]
+
+    def _match(name):
+        for fn in all_items:
+            if fn.__name__ == name:
+                return fn
+        raise ValueError(f"cannot find item with name {name}")
+
+    parser = argparse.ArgumentParser(
+        description="Generate computed fields and check invariants"
+    )
+    parser.add_argument(
+        "--items",
+        nargs="+",
+        help="which items to run",
+        default=None,
+        required=False,
+    )
+
+
+    print("[Replacing old tables with staged]")
+
+    conn = database.Engine.connect()
+    meta = MetaData(bind=database.Engine)
+    meta.reflect()
+
+    constraints = []
+    indexes = []
+
+    replace = conn.begin()
+    conn.execute("SET CONSTRAINTS ALL DEFERRED;")
+
+    # drop and update tables in reverse dependnecy order
+    for table in meta.sorted_tables[::-1]:
+        if not table.name.endswith("_staged"):
+            print(f"Updating table {table.name}")
+            for index in table.indexes:
+                indexes.append(index)
+            for constraint in table.constraints:
+                constraints.append(constraint)
+            conn.execute(f'DROP TABLE IF EXISTS {table.name}_old;')
+            conn.execute(f'ALTER TABLE "{table.name}" RENAME TO {table.name}_old;')
+            conn.execute(f'ALTER TABLE "{table.name}_staged" RENAME TO {table.name};')
+
+    replace.commit()
+
+    # attempt to update tables with staged, checking invariants
+    try:
+
+        print("[Checking table invariants]")
+
+        # check invariants
+        args = parser.parse_args()
+        if args.items:
+            items = [_match(name) for name in args.items]
+        else:
+            items = all_items
+
+        for fn in items:
+            if fn.__doc__:
+                tqdm.write(f"{fn.__doc__.strip()}")
+            else:
+                tqdm.write(f"Running: {fn.__name__}")
+
+            with database.session_scope(database.Session) as session:
+                fn(session)
+
+        print("All invariants passed")
+
+    # if invariant checking fails, revert the replacements
+    except:
+
+        print("Invariant checking failed. Reverting tables.")
+
+        revert = conn.begin()
+        conn.execute("SET CONSTRAINTS ALL DEFERRED;")
+
+        for table in meta.sorted_tables[::-1]:
+            if not table.name.endswith("_staged"):
+                print(f"Reverting table {table.name}")
+                conn.execute(f'ALTER TABLE "{table.name}" RENAME TO {table.name}_staged;')
+                conn.execute(f'ALTER TABLE "{table.name}_old" RENAME TO {table.name};')
+
+        revert.commit()
+        raise
+
+
+    print("Deleting temporary old tables")
+    meta.reflect()
+    delete = conn.begin()
+    conn.execute("SET CONSTRAINTS ALL DEFERRED;")
+    for table in meta.sorted_tables[::-1]:
+        if table.name.endswith("_old"):
+            print(f"Dropping table {table.name}")
+            conn.execute(f'DROP TABLE IF EXISTS {table.name}')
+
+    delete.commit()
+
+    # add back the foreign key constraints
+    print("Regenerating constraints")
+    regen_constraints = conn.begin()
+    for constraint in constraints:
+        if isinstance(constraint, ForeignKeyConstraint):
+            conn.execute(schema.AddConstraint(constraint))
+    regen_constraints.commit()
+
+    def index_exists(name):
+        result = conn.execute(
+            "SELECT exists(SELECT 1 from pg_indexes where indexname = '{}') as ix_exists;"
+                .format(name)
+        ).first()
+        return result.ix_exists
+
+    print("Regenerating indexes")
+    regen_indexes = conn.begin()
+    for index in indexes:
+        if index_exists(index.name):
+            conn.execute(schema.DropIndex(index))
+        conn.execute(schema.CreateIndex(index))
+    regen_indexes.commit()
+
+    print("Reindexing")
+    conn.execution_options(isolation_level="AUTOCOMMIT").execute("VACUUM;")
+    conn.execution_options(isolation_level="AUTOCOMMIT").execute("REINDEX DATABASE postgres;")
+
+    # generate computed tables and full-text-search
+    print("Setting up search")
+    with database.session_scope(database.Session) as session:
+        search_setup(session)
+
+    # Print row counts for each table.
+    tqdm.write("\nTable Statistics")
+    with database.session_scope(database.Session) as session:
+        # Via https://stackoverflow.om/a/2611745/5004662.
+        sql = """
+        select table_schema,
+            table_name,
+            (xpath('/row/cnt/text()', xml_count))[1]::text::int as row_count
+        from (
+        select table_name, table_schema,
+                query_to_xml(format('select count(*) as cnt from %I.%I', table_schema, table_name), false, true, '') as xml_count
+        from information_schema.tables
+        where table_schema = 'public' --<< change here for the schema you want
+        ) t
+        """
+
+        result = session.execute(sql)
+        for table_counts in result:
+            print(f"{table_counts[1]:>25} - {table_counts[2]:6} rows")

--- a/ferry/importer.py
+++ b/ferry/importer.py
@@ -149,7 +149,9 @@ def import_demand(session, season, demand_info):
             database.Listing.course_code,
             database.Listing.course_id,
             database.Listing.section,
-        ).filter(database.Listing.course_code.in_(demand_info["codes"]))
+        )
+        .filter(database.Listing.course_code.in_(demand_info["codes"]))
+        .filter(database.Listing.season_code == season)
     ).all()
 
     unique_course_ids = set(listing[1] for listing in possible_course_ids)

--- a/ferry/importer.py
+++ b/ferry/importer.py
@@ -20,7 +20,9 @@ This script does not recalculate any computed values in the schema.
 def import_course(session, course_info):
     # Create season.
     season, _ = database.get_or_create(
-        session, database.Season, season_code=course_info["season_code"],
+        session,
+        database.Season,
+        season_code=course_info["season_code"],
     )
 
     # Find or create appropriate listing and course.
@@ -210,7 +212,9 @@ def import_evaluation(session, evaluation):
 
     # Enrollment statistics and extras
     statistics, _ = database.get_or_create(
-        session, database.EvaluationStatistics, course=course,
+        session,
+        database.EvaluationStatistics,
+        course=course,
     )
     statistics.enrolled = evaluation["enrollment"].get("enrolled", None)
     statistics.responses = evaluation["enrollment"].get("responses", None)
@@ -222,7 +226,9 @@ def import_evaluation(session, evaluation):
     # Resolve questions.
     def resolve_question(question_code, text, is_narrative, options=None):
         question, created = database.get_or_create(
-            session, database.EvaluationQuestion, question_code=question_code,
+            session,
+            database.EvaluationQuestion,
+            question_code=question_code,
         )
         if created:
             question.question_text = text

--- a/ferry/importer.py
+++ b/ferry/importer.py
@@ -20,9 +20,7 @@ This script does not recalculate any computed values in the schema.
 def import_course(session, course_info):
     # Create season.
     season, _ = database.get_or_create(
-        session,
-        database.Season,
-        season_code=course_info["season_code"],
+        session, database.Season, season_code=course_info["season_code"],
     )
 
     # Find or create appropriate listing and course.
@@ -210,19 +208,19 @@ def import_evaluation(session, evaluation):
 
     # Enrollment statistics and extras
     statistics, _ = database.get_or_create(
-        session,
-        database.EvaluationStatistics,
-        course=course,
+        session, database.EvaluationStatistics, course=course,
     )
-    database.update_json(statistics, "enrollment", evaluation["enrollment"])
+    statistics.enrolled = evaluation["enrollment"].get("enrolled", None)
+    statistics.responses = evaluation["enrollment"].get("responses", None)
+    statistics.declined = evaluation["enrollment"].get("declined", None)
+    statistics.no_response = evaluation["enrollment"].get("no response", None)
+
     database.update_json(statistics, "extras", evaluation["extras"])
 
     # Resolve questions.
     def resolve_question(question_code, text, is_narrative, options=None):
         question, created = database.get_or_create(
-            session,
-            database.EvaluationQuestion,
-            question_code=question_code,
+            session, database.EvaluationQuestion, question_code=question_code,
         )
         if created:
             question.question_text = text

--- a/ferry/importer.py
+++ b/ferry/importer.py
@@ -20,7 +20,9 @@ This script does not recalculate any computed values in the schema.
 def import_course(session, course_info):
     # Create season.
     season, _ = database.get_or_create(
-        session, database.Season, season_code=course_info["season_code"],
+        session,
+        database.Season,
+        season_code=course_info["season_code"],
     )
 
     # Find or create appropriate listing and course.
@@ -208,7 +210,9 @@ def import_evaluation(session, evaluation):
 
     # Enrollment statistics and extras
     statistics, _ = database.get_or_create(
-        session, database.EvaluationStatistics, course=course,
+        session,
+        database.EvaluationStatistics,
+        course=course,
     )
     database.update_json(statistics, "enrollment", evaluation["enrollment"])
     database.update_json(statistics, "extras", evaluation["extras"])
@@ -216,7 +220,9 @@ def import_evaluation(session, evaluation):
     # Resolve questions.
     def resolve_question(question_code, text, is_narrative, options=None):
         question, created = database.get_or_create(
-            session, database.EvaluationQuestion, question_code=question_code,
+            session,
+            database.EvaluationQuestion,
+            question_code=question_code,
         )
         if created:
             question.question_text = text

--- a/ferry/importer.py
+++ b/ferry/importer.py
@@ -20,9 +20,7 @@ This script does not recalculate any computed values in the schema.
 def import_course(session, course_info):
     # Create season.
     season, _ = database.get_or_create(
-        session,
-        database.Season,
-        season_code=course_info["season_code"],
+        session, database.Season, season_code=course_info["season_code"],
     )
 
     # Find or create appropriate listing and course.
@@ -210,9 +208,7 @@ def import_evaluation(session, evaluation):
 
     # Enrollment statistics and extras
     statistics, _ = database.get_or_create(
-        session,
-        database.EvaluationStatistics,
-        course=course,
+        session, database.EvaluationStatistics, course=course,
     )
     database.update_json(statistics, "enrollment", evaluation["enrollment"])
     database.update_json(statistics, "extras", evaluation["extras"])
@@ -220,9 +216,7 @@ def import_evaluation(session, evaluation):
     # Resolve questions.
     def resolve_question(question_code, text, is_narrative, options=None):
         question, created = database.get_or_create(
-            session,
-            database.EvaluationQuestion,
-            question_code=question_code,
+            session, database.EvaluationQuestion, question_code=question_code,
         )
         if created:
             question.question_text = text

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -159,6 +159,37 @@ if __name__ == "__main__":
         evaluation_questions,
     ) = import_evaluations(merged_evaluations_info, listings)
 
+    # define seasons table for import
+    seasons = pd.DataFrame(course_seasons, columns=["season_code"], dtype=int)
+    seasons["term"] = seasons["season_code"].apply(
+        lambda x: {"1": "spring", "2": "summer", "3": "fall"}[str(x)[-1]]
+    )
+    seasons["year"] = (
+        seasons["season_code"].astype(str).apply(lambda x: x[:4]).astype(int)
+    )
+
+    # -----------------------------
+    # Output tables to disk as CSVs
+    # -----------------------------
+
+    print("\n[Writing tables to disk as CSVs]")
+
+    csv_dir = config.DATA_DIR / "importer_dumps"
+
+    seasons.to_csv(csv_dir / "seasons.csv")
+
+    courses.to_csv(csv_dir / "courses.csv")
+    listings.to_csv(csv_dir / "listings.csv")
+    professors.to_csv(csv_dir / "professors.csv")
+    course_professors.to_csv(csv_dir / "course_professors.csv")
+
+    demand_statistics.to_csv(csv_dir / "demand_statistics.csv")
+
+    evaluation_questions.to_csv(csv_dir / "evaluation_questions.csv")
+    evaluation_narratives.to_csv(csv_dir / "evaluation_narratives.csv")
+    evaluation_ratings.to_csv(csv_dir / "evaluation_ratings.csv")
+    evaluation_statistics.to_csv(csv_dir / "evaluation_statistics.csv")
+
     # ------------------------
     # Replace tables in database
     # ------------------------
@@ -178,10 +209,7 @@ if __name__ == "__main__":
 
     raw_conn = database.Engine.raw_connection()
 
-    # insert new tables
-    seasons = pd.DataFrame(course_seasons, columns=["season_code"], dtype=int)
-    seasons["term"] = np.nan
-    seasons["year"] = np.nan
+    # seasons
     copy_from_stringio(raw_conn, seasons, "seasons")
 
     # courses

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -11,10 +11,13 @@ from sqlalchemy.ext.declarative import declarative_base
 
 from ferry import config, database
 from ferry.config import DATABASE_CONNECT_STRING
-from ferry.includes.computed import questions_computed, evaluation_statistics_computed
+from ferry.includes.computed import (
+    courses_computed,
+    evaluation_statistics_computed,
+    questions_computed,
+)
 from ferry.includes.importer import (
     copy_from_stringio,
-    get_all_tables,
     import_courses,
     import_demand,
     import_evaluations,
@@ -188,7 +191,11 @@ if __name__ == "__main__":
         print("Assigning question tags")
         evaluation_questions = questions_computed(evaluation_questions)
         print("Computing average ratings by course")
-        evaluation_statistics = evaluation_statistics_computed(evaluation_statistics, evaluation_ratings, evaluation_questions)
+        evaluation_statistics = evaluation_statistics_computed(
+            evaluation_statistics, evaluation_ratings, evaluation_questions
+        )
+        print("Computing historical ratings for courses")
+        courses = courses_computed(courses, listings, evaluation_statistics)
 
         # -----------------------------
         # Output tables to disk as CSVs

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -373,6 +373,27 @@ def import_evaluations(merged_evaluations_info, listings):
     evaluation_narratives = evaluation_narratives.explode("comment")
     evaluation_narratives = evaluation_narratives.reset_index(drop=True)
 
+    # extract evaluation ratings
+    evaluation_ratings = evaluations[evaluations["ratings"].apply(len) > 0].copy(
+        deep=True
+    )
+
+    evaluation_ratings = evaluation_ratings.loc[:, ["course_id", "ratings"]]
+    evaluation_ratings = evaluation_ratings.explode("ratings")
+
+    evaluation_ratings["question_code"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["question_id"]
+    )
+    evaluation_ratings["question_text"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["question_text"]
+    )
+    evaluation_ratings["options"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["options"]
+    )
+    evaluation_ratings["rating"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["data"]
+    )
+
     return evaluations
 
 

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     merged_demand_info = pd.concat(merged_demand_info, axis=0, sort=True)
     merged_demand_info = merged_demand_info.reset_index(drop=True)
 
-    demand_statistics = import_demand(merged_demand_info, listings, seasons)
+    demand_statistics = import_demand(merged_demand_info, listings, demand_seasons)
 
     # -------------------------
     # Import course evaluations
@@ -128,20 +128,11 @@ if __name__ == "__main__":
     previous_eval_files = [x.name for x in previous_eval_files]
     new_eval_files = [x.name for x in new_eval_files]
 
-    all_evals = list(set(previous_eval_files + new_eval_files))
-
-    # Filter by seasons.
-    if seasons is None:
-        evals_to_import = sorted(list(all_evals))
-
-    else:
-        evals_to_import = sorted(
-            filename for filename in all_evals if filename.split("-")[0] in seasons
-        )
+    all_evals = sorted(list(set(previous_eval_files + new_eval_files)))
 
     merged_evaluations_info = []
 
-    for filename in tqdm(evals_to_import, desc="Loading evaluation JSONs"):
+    for filename in tqdm(all_evals, desc="Loading evaluation JSONs"):
         # Read the evaluation, giving preference to current over previous.
         current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
 

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import ujson
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, Table
 from sqlalchemy.ext.declarative import declarative_base
 
 from ferry import config, database
@@ -30,179 +30,235 @@ This script does not recalculate any computed values in the schema.
 
 if __name__ == "__main__":
 
-    # ---------------------
-    # Get seasons to import
-    # ---------------------
-    # get full list of course seasons from files
-    course_seasons = sorted(
-        [
-            filename.split(".")[0]  # remove the .json extension
-            for filename in set(
-                os.listdir(f"{config.DATA_DIR}/migrated_courses/")
-                + os.listdir(f"{config.DATA_DIR}/parsed_courses/")
-            )
-            if filename[0] != "."
-        ]
+    parser = argparse.ArgumentParser(description="Import classes")
+    parser.add_argument(
+        "-c", "--cached", help="Load class tables from cached CSVs", action="store_true"
     )
+    args = parser.parse_args()
 
-    # get full list of demand seasons from files
-    demand_seasons = sorted(
-        [
-            filename.split("_")[0]  # remove the _demand.json suffix
-            for filename in os.listdir(f"{config.DATA_DIR}/demand_stats/")
-            if filename[0] != "." and filename != "subjects.json"
-        ]
-    )
+    if not args.cached:
 
-    # ----------------------
-    # Import course listings
-    # ----------------------
-
-    print("\n[Importing courses]")
-    print(f"Season(s): {', '.join(course_seasons)}")
-
-    merged_course_info = []
-
-    for season in tqdm(course_seasons, desc="Loading course JSONs"):
-        # Read the course listings, giving preference to freshly parsed over migrated ones.
-        parsed_courses_file = Path(f"{config.DATA_DIR}/parsed_courses/{season}.json")
-
-        if parsed_courses_file.is_file():
-            parsed_course_info = pd.read_json(parsed_courses_file)
-        else:
-            # check migrated courses as a fallback
-            migrated_courses_file = Path(
-                f"{config.DATA_DIR}/migrated_courses/{season}.json"
-            )
-
-            if not migrated_courses_file.is_file():
-                print(
-                    f"Skipping season {season}: not found in parsed or migrated courses."
+        # ---------------------
+        # Get seasons to import
+        # ---------------------
+        # get full list of course seasons from files
+        course_seasons = sorted(
+            [
+                filename.split(".")[0]  # remove the .json extension
+                for filename in set(
+                    os.listdir(f"{config.DATA_DIR}/migrated_courses/")
+                    + os.listdir(f"{config.DATA_DIR}/parsed_courses/")
                 )
+                if filename[0] != "."
+            ]
+        )
+
+        # get full list of demand seasons from files
+        demand_seasons = sorted(
+            [
+                filename.split("_")[0]  # remove the _demand.json suffix
+                for filename in os.listdir(f"{config.DATA_DIR}/demand_stats/")
+                if filename[0] != "." and filename != "subjects.json"
+            ]
+        )
+
+        # ----------------------
+        # Import course listings
+        # ----------------------
+
+        print("\n[Importing courses]")
+        print(f"Season(s): {', '.join(course_seasons)}")
+
+        merged_course_info = []
+
+        for season in tqdm(course_seasons, desc="Loading course JSONs"):
+            # Read the course listings, giving preference to freshly parsed over migrated ones.
+            parsed_courses_file = Path(
+                f"{config.DATA_DIR}/parsed_courses/{season}.json"
+            )
+
+            if parsed_courses_file.is_file():
+                parsed_course_info = pd.read_json(parsed_courses_file)
+            else:
+                # check migrated courses as a fallback
+                migrated_courses_file = Path(
+                    f"{config.DATA_DIR}/migrated_courses/{season}.json"
+                )
+
+                if not migrated_courses_file.is_file():
+                    print(
+                        f"Skipping season {season}: not found in parsed or migrated courses."
+                    )
+                    continue
+                with open(migrated_courses_file, "r") as f:
+                    parsed_course_info = pd.read_json(migrated_courses_file)
+
+            parsed_course_info["season_code"] = season
+            merged_course_info.append(parsed_course_info)
+
+        merged_course_info = pd.concat(merged_course_info, axis=0)
+        merged_course_info = merged_course_info.reset_index(drop=True)
+
+        courses, listings, course_professors, professors = import_courses(
+            merged_course_info, course_seasons
+        )
+
+        # ------------------------
+        # Import demand statistics
+        # ------------------------
+
+        merged_demand_info = []
+
+        print("\n[Importing demand statistics]")
+        print(f"Season(s): {', '.join(demand_seasons)}")
+        for season in tqdm(demand_seasons, desc="Loading demand JSONs"):
+
+            demand_file = Path(f"{config.DATA_DIR}/demand_stats/{season}_demand.json")
+
+            if not demand_file.is_file():
+                print(f"Skipping season {season}: demand statistics file not found.")
                 continue
-            with open(migrated_courses_file, "r") as f:
-                parsed_course_info = pd.read_json(migrated_courses_file)
 
-        parsed_course_info["season_code"] = season
-        merged_course_info.append(parsed_course_info)
+            with open(demand_file, "r") as f:
+                demand_info = pd.read_json(f)
 
-    merged_course_info = pd.concat(merged_course_info, axis=0)
-    merged_course_info = merged_course_info.reset_index(drop=True)
+            demand_info["season_code"] = season
+            merged_demand_info.append(demand_info)
 
-    courses, listings, course_professors, professors = import_courses(
-        merged_course_info, course_seasons
-    )
+        merged_demand_info = pd.concat(merged_demand_info, axis=0)
+        merged_demand_info = merged_demand_info.reset_index(drop=True)
 
-    # ------------------------
-    # Import demand statistics
-    # ------------------------
+        demand_statistics = import_demand(merged_demand_info, listings, demand_seasons)
 
-    merged_demand_info = []
+        # -------------------------
+        # Import course evaluations
+        # -------------------------
 
-    print("\n[Importing demand statistics]")
-    print(f"Season(s): {', '.join(demand_seasons)}")
-    for season in tqdm(demand_seasons, desc="Loading demand JSONs"):
+        print("\n[Importing course evaluations]")
 
-        demand_file = Path(f"{config.DATA_DIR}/demand_stats/{season}_demand.json")
+        # list available evaluation files
+        previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
+        new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
 
-        if not demand_file.is_file():
-            print(f"Skipping season {season}: demand statistics file not found.")
-            continue
+        previous_eval_files = [x.name for x in previous_eval_files]
+        new_eval_files = [x.name for x in new_eval_files]
 
-        with open(demand_file, "r") as f:
-            demand_info = pd.read_json(f)
+        all_evals = sorted(list(set(previous_eval_files + new_eval_files)))
 
-        demand_info["season_code"] = season
-        merged_demand_info.append(demand_info)
+        merged_evaluations_info = []
 
-    merged_demand_info = pd.concat(merged_demand_info, axis=0)
-    merged_demand_info = merged_demand_info.reset_index(drop=True)
+        for filename in tqdm(all_evals, desc="Loading evaluation JSONs"):
+            # Read the evaluation, giving preference to current over previous.
+            current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
 
-    demand_statistics = import_demand(merged_demand_info, listings, demand_seasons)
+            if current_evals_file.is_file():
+                with open(current_evals_file, "r") as f:
+                    evaluation = ujson.load(f)
+            else:
+                with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
+                    evaluation = ujson.load(f)
 
-    # -------------------------
-    # Import course evaluations
-    # -------------------------
+            merged_evaluations_info.append(evaluation)
 
-    print("\n[Importing course evaluations]")
+        merged_evaluations_info = pd.DataFrame(merged_evaluations_info)
 
-    # list available evaluation files
-    previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
-    new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
+        (
+            evaluation_narratives,
+            evaluation_ratings,
+            evaluation_statistics,
+            evaluation_questions,
+        ) = import_evaluations(merged_evaluations_info, listings)
 
-    previous_eval_files = [x.name for x in previous_eval_files]
-    new_eval_files = [x.name for x in new_eval_files]
+        # define seasons table for import
+        seasons = pd.DataFrame(course_seasons, columns=["season_code"], dtype=int)
+        seasons["term"] = seasons["season_code"].apply(
+            lambda x: {"1": "spring", "2": "summer", "3": "fall"}[str(x)[-1]]
+        )
+        seasons["year"] = (
+            seasons["season_code"].astype(str).apply(lambda x: x[:4]).astype(int)
+        )
 
-    all_evals = sorted(list(set(previous_eval_files + new_eval_files)))
+        # -----------------------------
+        # Output tables to disk as CSVs
+        # -----------------------------
 
-    merged_evaluations_info = []
+        print("\n[Writing tables to disk as CSVs]")
 
-    for filename in tqdm(all_evals, desc="Loading evaluation JSONs"):
-        # Read the evaluation, giving preference to current over previous.
-        current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
+        csv_dir = config.DATA_DIR / "importer_dumps"
 
-        if current_evals_file.is_file():
-            with open(current_evals_file, "r") as f:
-                evaluation = ujson.load(f)
-        else:
-            with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
-                evaluation = ujson.load(f)
+        seasons.to_csv(csv_dir / "seasons.csv")
 
-        merged_evaluations_info.append(evaluation)
+        courses.to_csv(csv_dir / "courses.csv")
+        listings.to_csv(csv_dir / "listings.csv")
+        professors.to_csv(csv_dir / "professors.csv")
+        course_professors.to_csv(csv_dir / "course_professors.csv")
 
-    merged_evaluations_info = pd.DataFrame(merged_evaluations_info)
+        demand_statistics.to_csv(csv_dir / "demand_statistics.csv")
 
-    (
-        evaluation_narratives,
-        evaluation_ratings,
-        evaluation_statistics,
-        evaluation_questions,
-    ) = import_evaluations(merged_evaluations_info, listings)
+        evaluation_questions.to_csv(csv_dir / "evaluation_questions.csv")
+        evaluation_narratives.to_csv(csv_dir / "evaluation_narratives.csv")
+        evaluation_ratings.to_csv(csv_dir / "evaluation_ratings.csv")
+        evaluation_statistics.to_csv(csv_dir / "evaluation_statistics.csv")
 
-    # define seasons table for import
-    seasons = pd.DataFrame(course_seasons, columns=["season_code"], dtype=int)
-    seasons["term"] = seasons["season_code"].apply(
-        lambda x: {"1": "spring", "2": "summer", "3": "fall"}[str(x)[-1]]
-    )
-    seasons["year"] = (
-        seasons["season_code"].astype(str).apply(lambda x: x[:4]).astype(int)
-    )
+    elif args.cached:
 
-    # -----------------------------
-    # Output tables to disk as CSVs
-    # -----------------------------
+        print("\n[Reading in tables from CSVs]")
 
-    print("\n[Writing tables to disk as CSVs]")
+        csv_dir = config.DATA_DIR / "importer_dumps"
 
-    csv_dir = config.DATA_DIR / "importer_dumps"
+        seasons = pd.read_csv(csv_dir / "seasons.csv", index_col=0)
 
-    seasons.to_csv(csv_dir / "seasons.csv")
+        courses = pd.read_csv(csv_dir / "courses.csv", index_col=0)
+        listings = pd.read_csv(csv_dir / "listings.csv", index_col=0)
+        professors = pd.read_csv(csv_dir / "professors.csv", index_col=0)
+        course_professors = pd.read_csv(csv_dir / "course_professors.csv", index_col=0)
 
-    courses.to_csv(csv_dir / "courses.csv")
-    listings.to_csv(csv_dir / "listings.csv")
-    professors.to_csv(csv_dir / "professors.csv")
-    course_professors.to_csv(csv_dir / "course_professors.csv")
+        demand_statistics = pd.read_csv(csv_dir / "demand_statistics.csv", index_col=0)
 
-    demand_statistics.to_csv(csv_dir / "demand_statistics.csv")
-
-    evaluation_questions.to_csv(csv_dir / "evaluation_questions.csv")
-    evaluation_narratives.to_csv(csv_dir / "evaluation_narratives.csv")
-    evaluation_ratings.to_csv(csv_dir / "evaluation_ratings.csv")
-    evaluation_statistics.to_csv(csv_dir / "evaluation_statistics.csv")
+        evaluation_questions = pd.read_csv(
+            csv_dir / "evaluation_questions.csv", index_col=0
+        )
+        evaluation_narratives = pd.read_csv(
+            csv_dir / "evaluation_narratives.csv", index_col=0
+        )
+        evaluation_ratings = pd.read_csv(
+            csv_dir / "evaluation_ratings.csv", index_col=0
+        )
+        evaluation_statistics = pd.read_csv(
+            csv_dir / "evaluation_statistics.csv", index_col=0
+        )
 
     # ------------------------
     # Replace tables in database
     # ------------------------
     print("\n[Clearing database]")
 
-    # drop old tables
     meta = MetaData(bind=database.Engine, reflect=True)
+    staging_tables = []
+
+    for table in meta.sorted_tables:
+        if not table.name.endswith("_staged"):
+            args = []
+            for column in table.columns:
+                args.append(column.copy())
+            for constraint in table.constraints:
+                args.append(constraint.copy())
+            staging_tables.append(
+                Table(
+                    f"{table.name}_staged", table.metadata, extend_existing=True, *args
+                )
+            )
+
+    meta.create_all(tables=staging_tables)
+
+    # drop old tables
     conn = database.Engine.connect()
     delete = conn.begin()
     for table in meta.sorted_tables:
-        conn.execute(f'ALTER TABLE "{table.name}" DISABLE TRIGGER ALL;')
-        conn.execute(table.delete())
-        conn.execute(f'ALTER TABLE "{table.name}" ENABLE TRIGGER ALL;')
+        if table.name.endswith("_staged"):
+            conn.execute(f'ALTER TABLE "{table.name}" DISABLE TRIGGER ALL;')
+            conn.execute(table.delete())
+            conn.execute(f'ALTER TABLE "{table.name}" ENABLE TRIGGER ALL;')
     delete.commit()
 
     print("\n[Updating database]")
@@ -210,22 +266,22 @@ if __name__ == "__main__":
     raw_conn = database.Engine.raw_connection()
 
     # seasons
-    copy_from_stringio(raw_conn, seasons, "seasons")
+    copy_from_stringio(raw_conn, seasons, "seasons_staged")
 
     # courses
-    copy_from_stringio(raw_conn, courses, "courses")
-    copy_from_stringio(raw_conn, listings, "listings")
-    copy_from_stringio(raw_conn, professors, "professors")
-    copy_from_stringio(raw_conn, course_professors, "course_professors")
+    copy_from_stringio(raw_conn, courses, "courses_staged")
+    copy_from_stringio(raw_conn, listings, "listings_staged")
+    copy_from_stringio(raw_conn, professors, "professors_staged")
+    copy_from_stringio(raw_conn, course_professors, "course_professors_staged")
 
     # demand statistics
-    copy_from_stringio(raw_conn, demand_statistics, "demand_statistics")
+    copy_from_stringio(raw_conn, demand_statistics, "demand_statistics_staged")
 
     # evaluations
-    copy_from_stringio(raw_conn, evaluation_questions, "evaluation_questions")
-    copy_from_stringio(raw_conn, evaluation_narratives, "evaluation_narratives")
-    copy_from_stringio(raw_conn, evaluation_ratings, "evaluation_ratings")
-    copy_from_stringio(raw_conn, evaluation_statistics, "evaluation_statistics")
+    copy_from_stringio(raw_conn, evaluation_questions, "evaluation_questions_staged")
+    copy_from_stringio(raw_conn, evaluation_narratives, "evaluation_narratives_staged")
+    copy_from_stringio(raw_conn, evaluation_ratings, "evaluation_ratings_staged")
+    copy_from_stringio(raw_conn, evaluation_statistics, "evaluation_statistics_staged")
 
     print("Committing new tables")
     raw_conn.commit()

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -14,8 +14,8 @@ from ferry.config import DATABASE_CONNECT_STRING
 from ferry.includes.computed import (
     courses_computed,
     evaluation_statistics_computed,
+    professors_computed,
     questions_computed,
-    professors_computed
 )
 from ferry.includes.importer import (
     copy_from_stringio,
@@ -198,7 +198,9 @@ if __name__ == "__main__":
         print("Computing historical ratings for courses")
         courses = courses_computed(courses, listings, evaluation_statistics)
         print("Computing ratings for professors")
-        professors = professors_computed(professors, course_professors, evaluation_statistics)
+        professors = professors_computed(
+            professors, course_professors, evaluation_statistics
+        )
 
         # -----------------------------
         # Output tables to disk as CSVs

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -1,18 +1,20 @@
 import argparse
 import os
-from collections import Counter
-from itertools import combinations
+
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import textdistance
 import ujson
 
 from ferry import config, database
-from ferry.includes.importer import get_all_tables
+from ferry.includes.importer import (
+    get_all_tables,
+    import_courses,
+    import_demand,
+    import_evaluations,
+)
 from ferry.includes.tqdm import tqdm
-from ferry.includes.utils import invert_dict_of_lists, merge_overlapping
 
 """
 ================================================================
@@ -21,498 +23,6 @@ It creates or updates the tables as necessary, so this script is idempotent.
 This script does not recalculate any computed values in the schema.
 ================================================================
 """
-
-
-def import_courses(merged_course_info, seasons):
-
-    # seasons must be sorted in ascending order
-
-    print("Aggregating cross-listings")
-    merged_course_info["season_code"] = merged_course_info["season_code"].astype(int)
-    merged_course_info["crn"] = merged_course_info["crn"].astype(int)
-    merged_course_info["crns"] = merged_course_info["crns"].apply(lambda x: map(int, x))
-
-    # group CRNs by season for cross-listing deduplication
-    crns_by_season = merged_course_info.groupby("season_code")["crns"].apply(list)
-    # convert CRN groups to sets for resolution
-    crns_by_season = crns_by_season.apply(lambda x: [set(y) for y in x])
-    # resolve overlapping CRN sets
-    crn_groups_by_season = crns_by_season.apply(merge_overlapping)
-
-    print("Mapping out cross-listings")
-    # map CRN groups to IDs
-    temp_course_ids_by_season = crns_by_season.apply(
-        lambda x: invert_dict_of_lists(dict(enumerate(x)))
-    )
-    temp_course_ids_by_season = temp_course_ids_by_season.to_dict()
-
-    # assign season-specific ID based on CRN group IDs
-    merged_course_info["season_course_id"] = merged_course_info.apply(
-        lambda row: temp_course_ids_by_season[row["season_code"]][row["crn"]], axis=1
-    )
-    # temporary string-based unique course identifier
-    merged_course_info["temp_course_id"] = merged_course_info.apply(
-        lambda x: f"{x['season_code']}_{x['season_course_id']}", axis=1
-    )
-
-    print("Creating courses table")
-    # initialize courses table
-    courses = merged_course_info.drop_duplicates(subset="temp_course_id").copy(
-        deep=True
-    )
-    courses["course_id"] = range(len(courses))
-
-    print("Creating listings table")
-    temp_to_course_id = dict(zip(courses["temp_course_id"], courses["course_id"]))
-
-    # initialize listings table
-    listings = merged_course_info.copy(deep=True)
-    listings["listing_id"] = range(len(listings))
-    listings["course_id"] = listings["temp_course_id"].apply(temp_to_course_id.get)
-
-    print("Creating professors table")
-    # initialize professors table
-    professors_prep = courses.loc[
-        :,
-        ["season_code", "course_id", "professors", "professor_emails", "professor_ids"],
-    ]
-
-    print("Resolving professor attributes")
-    professors_prep["professors"] = professors_prep["professors"].apply(
-        lambda x: x if x == x else []
-    )
-    professors_prep["professor_emails"] = professors_prep["professor_emails"].apply(
-        lambda x: x if x == x else []
-    )
-    professors_prep["professor_ids"] = professors_prep["professor_ids"].apply(
-        lambda x: x if x == x else []
-    )
-
-    professors_prep["professors_info"] = professors_prep[
-        ["professors", "professor_emails", "professor_ids"]
-    ].to_dict(orient="split")["data"]
-
-    def zip_professors_info(professors_info):
-
-        names, emails, ocs_ids = professors_info
-
-        names = list(filter(lambda x: x != "", names))
-        emails = list(filter(lambda x: x != "", emails))
-        ocs_ids = list(filter(lambda x: x != "", ocs_ids))
-
-        if len(names) == 0:
-            return []
-
-        # account for inconsistent lengths before zipping
-        if len(emails) != len(names):
-            emails = [None] * len(names)
-        if len(ocs_ids) != len(names):
-            ocs_ids = [None] * len(names)
-
-        return list(zip(names, emails, ocs_ids))
-
-    professors_prep["professors_info"] = professors_prep["professors_info"].apply(
-        zip_professors_info
-    )
-
-    professors_prep = professors_prep[professors_prep["professors_info"].apply(len) > 0]
-
-    # expand courses with multiple professors
-    professors_prep = professors_prep.loc[
-        :, ["season_code", "course_id", "professors_info"]
-    ].explode("professors_info")
-    professors_prep = professors_prep.reset_index(drop=True)
-
-    # expand professor info columns
-    professors_prep[["name", "email", "ocs_id"]] = pd.DataFrame(
-        professors_prep["professors_info"].tolist(), index=professors_prep.index
-    )
-
-    print("Constructing professors table in chronological order")
-    professors = pd.DataFrame(columns=["professor_id", "name", "email", "ocs_id"])
-
-    professors_by_season = professors_prep.groupby("season_code")
-
-    def get_professor_identifiers(professors):
-
-        names_ids = (
-            professors.dropna(subset=["name"])
-            .groupby("name")["professor_id"]
-            .apply(list)
-            .to_dict()
-        )
-        emails_ids = (
-            professors.dropna(subset=["email"])
-            .groupby("email")["professor_id"]
-            .apply(list)
-            .to_dict()
-        )
-        ocs_ids = (
-            professors.dropna(subset=["ocs_id"])
-            .groupby("ocs_id")["professor_id"]
-            .apply(list)
-            .to_dict()
-        )
-
-        return names_ids, emails_ids, ocs_ids
-
-    def match_professors(season_professors, professors):
-
-        names_ids, emails_ids, ocs_ids = get_professor_identifiers(professors)
-
-        # get ID matches by field
-        season_professors["name_matched_ids"] = season_professors["name"].apply(
-            lambda x: names_ids.get(x, [])
-        )
-        season_professors["email_matched_ids"] = season_professors["email"].apply(
-            lambda x: emails_ids.get(x, [])
-        )
-        season_professors["ocs_matched_ids"] = season_professors["ocs_id"].apply(
-            lambda x: ocs_ids.get(x, [])
-        )
-
-        season_professors["matched_ids_aggregate"] = (
-            season_professors["name_matched_ids"]
-            + season_professors["email_matched_ids"]
-            + season_professors["ocs_matched_ids"]
-        )
-
-        season_professors["matched_ids_aggregate"] = season_professors[
-            "matched_ids_aggregate"
-        ].apply(lambda x: x if len(x) > 0 else [np.nan])
-
-        professor_ids = season_professors["matched_ids_aggregate"].apply(
-            lambda x: Counter(x).most_common(1)[0][0]
-        )
-
-        return professor_ids
-
-    course_professors = []
-
-    # build professors table in order of seasons
-    for season in seasons:
-
-        season_professors = professors_by_season.get_group(int(season)).copy(deep=True)
-
-        # first-pass
-        season_professors["professor_id"] = match_professors(
-            season_professors, professors
-        )
-
-        professors_update = season_professors.drop_duplicates(
-            subset=["name", "email", "ocs_id"], keep="first"
-        ).copy(deep=True)
-
-        new_professors = professors_update[professors_update["professor_id"].isna()]
-
-        max_professor_id = max(list(professors["professor_id"]) + [0])
-        new_professor_ids = pd.Series(
-            range(max_professor_id + 1, max_professor_id + len(new_professors) + 1),
-            index=new_professors.index,
-            dtype=np.float64,
-        )
-        professors_update["professor_id"].update(new_professor_ids)
-        professors_update["professor_id"] = professors_update["professor_id"].astype(
-            int
-        )
-        professors_update = professors_update.drop_duplicates(
-            subset=["professor_id"], keep="first"
-        )
-        professors_update = professors_update.set_index("professor_id")
-
-        professors = professors.set_index("professor_id", drop=True)
-        professors = professors_update[professors.columns].combine_first(professors)
-        professors = professors.reset_index(drop=False)
-
-        # second-pass
-        season_professors["professor_id"] = match_professors(
-            season_professors, professors
-        )
-
-        course_professors.append(season_professors[["course_id", "professor_id"]])
-
-    course_professors = pd.concat(course_professors, axis=0, sort=True)
-
-    return courses, listings, course_professors, professors
-
-
-def import_demand(merged_demand_info, listings, seasons):
-
-    demand_statistics = merged_demand_info.copy(deep=True)
-
-    # construct outer season grouping
-    season_code_to_course_id = listings[
-        ["season_code", "course_code", "course_id"]
-    ].groupby("season_code")
-
-    # construct inner course_code to course_id mapping
-    season_code_to_course_id = season_code_to_course_id.apply(
-        lambda x: x[["course_code", "course_id"]]
-        .groupby("course_code")["course_id"]
-        .apply(list)
-        .to_dict()
-    )
-
-    # cast outer season mapping to dictionary
-    season_code_to_course_id = season_code_to_course_id.to_dict()
-
-    def match_demand_to_courses(row):
-        season_code = int(row["season_code"])
-
-        course_ids = [
-            season_code_to_course_id.get(season_code, {}).get(x, None)
-            for x in row["codes"]
-        ]
-
-        course_ids = [set(x) for x in course_ids if x is not None]
-
-        if course_ids == []:
-            return []
-
-        # union all course IDs
-        course_ids = set.union(*course_ids)
-        course_ids = sorted(list(course_ids))
-
-        return course_ids
-
-    demand_statistics["course_id"] = demand_statistics.apply(
-        match_demand_to_courses, axis=1
-    )
-
-    demand_statistics = demand_statistics.loc[
-        demand_statistics["course_id"].apply(len) > 0, :
-    ]
-
-    def date_to_int(date):
-        month, day = date.split("/")
-
-        month = int(month)
-        day = int(day)
-
-        return month * 100 + day
-
-    def get_most_recent_demand(row):
-
-        sorted_demand = list(row["overall_demand"].items())
-        sorted_demand.sort(key=lambda x: date_to_int(x[0]))
-        latest_demand_date, latest_demand = sorted_demand[-1]
-
-        return [latest_demand, latest_demand_date]
-
-    # get most recent demand date
-    latest = demand_statistics.apply(get_most_recent_demand, axis=1)
-    demand_statistics[["latest_demand", "latest_demand_date"]] = pd.DataFrame(
-        latest.values.tolist()
-    )
-
-    # expand course_id list to one per row
-    demand_statistics = demand_statistics.explode("course_id")
-
-    # rename demand JSON column to match database
-    demand_statistics = demand_statistics.rename(
-        {"overall_demand": "demand"}, axis="columns"
-    )
-
-    # return columns of interest
-    demand_statistics = demand_statistics.loc[
-        :, ["course_id", "latest_demand", "latest_demand_date", "demand"]
-    ]
-
-    return demand_statistics
-
-
-def import_evaluations(merged_evaluations_info, listings):
-
-    evaluations = merged_evaluations_info.copy(deep=True)
-
-    # construct outer season grouping
-    season_crn_to_course_id = listings[["season_code", "course_id", "crn"]].groupby(
-        "season_code"
-    )
-
-    # construct inner course_code to course_id mapping
-    season_crn_to_course_id = season_crn_to_course_id.apply(
-        lambda x: x[["crn", "course_id"]].set_index("crn")["course_id"].to_dict()
-    )
-
-    # cast outer season mapping to dictionary
-    season_crn_to_course_id = season_crn_to_course_id.to_dict()
-
-    # convert evaluation season and crn types for matching
-    evaluations["season"] = evaluations["season"].astype(int)
-    evaluations["crn_code"] = evaluations["crn_code"].astype(int)
-
-    # find course codes for evaluations
-    evaluations["course_id"] = evaluations.apply(
-        lambda row: season_crn_to_course_id.get(row["season"], {}).get(
-            row["crn_code"], None
-        ),
-        axis=1,
-    )
-
-    # report number of evaluations with missing course codes
-    nan_total = evaluations["course_id"].isna().sum()
-    print(f"Removing {nan_total}/{len(evaluations)} evaluated courses without matches")
-
-    # remove evaluations with missing course codes
-    evaluations = evaluations.dropna(subset=["course_id"], axis=0)
-    evaluations["course_id"] = evaluations["course_id"].astype(int)
-
-    evaluation_questions = []
-
-    # extract evaluation narratives
-    evaluation_narratives = evaluations[evaluations["narratives"].apply(len) > 0].copy(
-        deep=True
-    )
-
-    evaluation_narratives = evaluation_narratives.loc[
-        :, ["course_id", "narratives", "season"]
-    ]
-
-    # expand each question into own column
-    evaluation_narratives = evaluation_narratives.explode("narratives")
-    evaluation_narratives["question_code"] = evaluation_narratives["narratives"].apply(
-        lambda x: x["question_id"]
-    )
-    evaluation_narratives["question_text"] = evaluation_narratives["narratives"].apply(
-        lambda x: x["question_text"]
-    )
-    evaluation_narratives["comment"] = evaluation_narratives["narratives"].apply(
-        lambda x: x["comments"]
-    )
-
-    evaluation_narratives["is_narrative"] = True
-    evaluation_questions.append(
-        evaluation_narratives.loc[
-            :, ["season", "question_code", "is_narrative", "question_text"]
-        ].copy(deep=True)
-    )
-
-    # subset and explode
-    evaluation_narratives = evaluation_narratives.loc[
-        :, ["course_id", "question_code", "comment"]
-    ]
-    evaluation_narratives = evaluation_narratives.explode("comment")
-    evaluation_narratives = evaluation_narratives.reset_index(drop=True)
-
-    # extract evaluation ratings
-    evaluation_ratings = evaluations[evaluations["ratings"].apply(len) > 0].copy(
-        deep=True
-    )
-
-    evaluation_ratings = evaluation_ratings.loc[:, ["course_id", "ratings", "season"]]
-    evaluation_ratings = evaluation_ratings.explode("ratings")
-
-    evaluation_ratings["question_code"] = evaluation_ratings["ratings"].apply(
-        lambda x: x["question_id"]
-    )
-    evaluation_ratings["question_text"] = evaluation_ratings["ratings"].apply(
-        lambda x: x["question_text"]
-    )
-    evaluation_ratings["options"] = evaluation_ratings["ratings"].apply(
-        lambda x: x["options"]
-    )
-    evaluation_ratings["rating"] = evaluation_ratings["ratings"].apply(
-        lambda x: x["data"]
-    )
-
-    evaluation_ratings["is_narrative"] = False
-    evaluation_questions.append(
-        evaluation_ratings.loc[
-            :, ["question_code", "is_narrative", "question_text", "options", "season"]
-        ].copy(deep=True)
-    )
-
-    # extract evaluation statistics
-    evaluation_statistics = evaluations.loc[
-        :, ["course_id", "enrollment", "extras"]
-    ].copy(deep=True)
-    evaluation_statistics["enrolled"] = evaluation_statistics["enrollment"].apply(
-        lambda x: x["enrolled"]
-    )
-    evaluation_statistics["responses"] = evaluation_statistics["enrollment"].apply(
-        lambda x: x["responses"]
-    )
-    evaluation_statistics["declined"] = evaluation_statistics["enrollment"].apply(
-        lambda x: x["declined"]
-    )
-    evaluation_statistics["no_response"] = evaluation_statistics["enrollment"].apply(
-        lambda x: x["no response"]
-    )
-
-    evaluation_statistics = evaluation_statistics.loc[
-        :, ["course_id", "enrolled", "responses", "declined", "no_response", "extras"]
-    ]
-
-    evaluation_questions = pd.concat(evaluation_questions, axis=0, sort=True)
-    evaluation_questions = evaluation_questions.reset_index(drop=True)
-
-    # consistency checks
-    print("Checking question text consistency")
-    text_by_code = evaluation_questions.groupby("question_code")["question_text"].apply(
-        set
-    )
-
-    # focus on question texts with multiple variations
-    text_by_code = text_by_code[text_by_code.apply(len) > 1]
-    max_diff_texts = max(text_by_code.apply(len))
-    print(f"Maximum number of different texts per question code: {max_diff_texts}")
-
-    def min_pairwise_distance(texts):
-
-        pairs = combinations(texts, 2)
-        distances = [textdistance.levenshtein.distance(*pair) for pair in pairs]
-
-        return max(distances)
-
-    distances_by_code = text_by_code.apply(min_pairwise_distance)
-    max_all_distances = max(distances_by_code)
-
-    print(f"Maximum text divergence within codes: {max_all_distances}")
-
-    if not all(distances_by_code < 32):
-
-        inconsistent_codes = distances_by_code[distances_by_code >= 32]
-        inconsistent_codes = list(inconsistent_codes.index)
-        inconsistent_codes = ", ".join(inconsistent_codes)
-
-        raise database.InvariantError(
-            f"Error: question codes {inconsistent_codes} have divergent texts"
-        )
-
-    print("Checking question type (narrative/rating) consistency")
-    is_narrative_by_code = evaluation_questions.groupby("question_code")[
-        "is_narrative"
-    ].apply(set)
-
-    if not all(is_narrative_by_code.apply(len) == 1):
-        inconsistent_codes = is_narrative_by_code[is_narrative_by_code.apply(len) != 1]
-        inconsistent_codes = list(inconsistent_codes.index)
-        inconsistent_codes = ", ".join(inconsistent_codes)
-        raise database.InvariantError(
-            f"Error: question codes {inconsistent_codes} have both narratives and ratings"
-        )
-
-    # deduplicate questions and keep most recent
-    evaluation_questions = evaluation_questions.sort_values(
-        by="season", ascending=False
-    )
-    evaluation_questions = evaluation_questions.drop_duplicates(
-        subset=["question_code"], keep="first"
-    )
-
-    print(f"Total evaluation narratives: {len(evaluation_narratives)}")
-    print(f"Total evaluation ratings: {len(evaluation_ratings)}")
-    print(f"Total evaluation statistics: {len(evaluation_statistics)}")
-    print(f"Total evaluation questions: {len(evaluation_questions)}")
-
-    return (
-        evaluation_narratives,
-        evaluation_ratings,
-        evaluation_statistics,
-        evaluation_questions,
-    )
-
 
 if __name__ == "__main__":
     # allow the user to specify seasons (useful for testing and debugging)
@@ -564,8 +74,13 @@ if __name__ == "__main__":
         course_seasons = seasons
         demand_seasons = seasons
 
+    # ----------------------
+    # Import course listings
+    # ----------------------
+
     # Course listings.
-    print(f"Importing courses for season(s): {', '.join(course_seasons)}")
+    print("\n[Importing courses]")
+    print(f"Season(s): {', '.join(course_seasons)}")
 
     merged_course_info = []
 
@@ -599,16 +114,14 @@ if __name__ == "__main__":
         merged_course_info, course_seasons
     )
 
-    print(f"Total courses: {len(courses)}")
-    print(f"Total listings: {len(listings)}")
-    print(f"Total course-professors: {len(course_professors)}")
-    print(f"Total professors: {len(professors)}")
-
-    # Course demand.
+    # ------------------------
+    # Import demand statistics
+    # ------------------------
 
     merged_demand_info = []
 
-    print(f"Importing demand stats for seasons: {', '.join(demand_seasons)}")
+    print("\n[Importing demand statistics]")
+    print(f"Season(s): {', '.join(demand_seasons)}")
     for season in demand_seasons:
 
         demand_file = Path(f"{config.DATA_DIR}/demand_stats/{season}_demand.json")
@@ -628,7 +141,11 @@ if __name__ == "__main__":
 
     demand_statistics = import_demand(merged_demand_info, listings, seasons)
 
-    print(f"Total demand statistics: {len(demand_statistics)}")
+    # -------------------------
+    # Import course evaluations
+    # -------------------------
+
+    print("\n[Importing course evaluations]")
 
     all_evals = [
         filename
@@ -650,7 +167,7 @@ if __name__ == "__main__":
 
     merged_evaluations_info = []
 
-    for filename in tqdm(evals_to_import, desc="Importing evaluations"):
+    for filename in tqdm(evals_to_import, desc="Loading evaluations"):
         # Read the evaluation, giving preference to current over previous.
         current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
 

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -77,13 +77,12 @@ if __name__ == "__main__":
     # Import course listings
     # ----------------------
 
-    # Course listings.
     print("\n[Importing courses]")
     print(f"Season(s): {', '.join(course_seasons)}")
 
     merged_course_info = []
 
-    for season in course_seasons:
+    for season in tqdm(course_seasons, desc="Loading course JSONs"):
         # Read the course listings, giving preference to freshly parsed over migrated ones.
         parsed_courses_file = Path(f"{config.DATA_DIR}/parsed_courses/{season}.json")
 
@@ -121,7 +120,7 @@ if __name__ == "__main__":
 
     print("\n[Importing demand statistics]")
     print(f"Season(s): {', '.join(demand_seasons)}")
-    for season in demand_seasons:
+    for season in tqdm(demand_seasons, desc="Loading demand JSONs"):
 
         demand_file = Path(f"{config.DATA_DIR}/demand_stats/{season}_demand.json")
 
@@ -146,14 +145,14 @@ if __name__ == "__main__":
 
     print("\n[Importing course evaluations]")
 
-    all_evals = [
-        filename
-        for filename in set(
-            os.listdir(f"{config.DATA_DIR}/previous_evals/")
-            + os.listdir(f"{config.DATA_DIR}/course_evals/")
-        )
-        if filename[0] != "."
-    ]
+    # list available evaluation files
+    previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
+    new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
+
+    previous_eval_files = [x.name for x in previous_eval_files]
+    new_eval_files = [x.name for x in new_eval_files]
+
+    all_evals = list(set(previous_eval_files + new_eval_files))
 
     # Filter by seasons.
     if seasons is None:
@@ -166,7 +165,7 @@ if __name__ == "__main__":
 
     merged_evaluations_info = []
 
-    for filename in tqdm(evals_to_import, desc="Loading evaluations"):
+    for filename in tqdm(evals_to_import, desc="Loading evaluation JSONs"):
         # Read the evaluation, giving preference to current over previous.
         current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
 

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -348,6 +348,31 @@ def import_evaluations(merged_evaluations_info, listings):
     evaluations = evaluations.dropna(subset=["course_id"], axis=0)
     evaluations["course_id"] = evaluations["course_id"].astype(int)
 
+    # extract evaluation narratives
+    evaluation_narratives = evaluations[evaluations["narratives"].apply(len) > 0].copy(
+        deep=True
+    )
+
+    evaluation_narratives = evaluation_narratives.loc[:, ["course_id", "narratives"]]
+
+    # expand each question into own column
+    evaluation_narratives = evaluation_narratives.explode("narratives")
+    evaluation_narratives["question_code"] = evaluation_narratives["narratives"].apply(
+        lambda x: x["question_id"]
+    )
+    evaluation_narratives["question_text"] = evaluation_narratives["narratives"].apply(
+        lambda x: x["question_text"]
+    )
+    evaluation_narratives["comment"] = evaluation_narratives["narratives"].apply(
+        lambda x: x["comments"]
+    )
+
+    evaluation_narratives = evaluation_narratives.loc[
+        :, ["course_id", "question_code", "comment"]
+    ]
+    evaluation_narratives = evaluation_narratives.explode("comment")
+    evaluation_narratives = evaluation_narratives.reset_index(drop=True)
+
     return evaluations
 
 

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -187,3 +187,5 @@ if __name__ == "__main__":
         evaluation_statistics,
         evaluation_questions,
     ) = import_evaluations(merged_evaluations_info, listings)
+
+    # breakpoint()

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -272,7 +272,6 @@ if __name__ == "__main__":
     # --------------------------
     print("\n[Clearing staging tables]")
 
-
     meta = MetaData(bind=database.Engine)
     meta.reflect()
 
@@ -295,10 +294,12 @@ if __name__ == "__main__":
                 args.append(column.copy())
             # note that we exclude constraints from the staging tables
             # for constraint in table.constraints:
-                # print(constraint)
-            staging_tables.append(Table(
+            # print(constraint)
+            staging_tables.append(
+                Table(
                     f"{table.name}_staged", table.metadata, extend_existing=True, *args
-                ))
+                )
+            )
 
     meta.create_all(tables=staging_tables)
 

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -1,0 +1,164 @@
+import argparse
+import os
+from pathlib import Path
+
+import textdistance
+import ujson
+
+from ferry import config, database
+from ferry.includes.tqdm import tqdm
+from ferry.includes.importer import get_all_tables
+
+"""
+================================================================
+This script imports the parsed course and evaluation data into the database.
+It creates or updates the tables as necessary, so this script is idempotent.
+This script does not recalculate any computed values in the schema.
+================================================================
+"""
+
+
+# def import_courses(tables, parsed_course_info):
+
+
+if __name__ == "__main__":
+    # allow the user to specify seasons (useful for testing and debugging)
+    parser = argparse.ArgumentParser(description="Import classes")
+    parser.add_argument(
+        "-s",
+        "--seasons",
+        nargs="+",
+        help="seasons to import (if empty, import all migrated+parsed courses)",
+        default=None,
+        required=False,
+    )
+    parser.add_argument(
+        "-m",
+        "--mode",
+        choices=["courses", "evals", "demand", "all"],
+        help="information to import: courses, evals, demand, or all (default)",
+        default="all",
+        required=False,
+    )
+
+    args = parser.parse_args()
+    seasons = args.seasons
+
+    # load all tables into Pandas
+    tables = get_all_tables(["public"])
+
+    # Course information.
+    if seasons is None:
+
+        # get full list of course seasons from files
+        course_seasons = sorted(
+            [
+                filename.split(".")[0]  # remove the .json extension
+                for filename in set(
+                    os.listdir(f"{config.DATA_DIR}/migrated_courses/")
+                    + os.listdir(f"{config.DATA_DIR}/parsed_courses/")
+                )
+                if filename[0] != "."
+            ]
+        )
+
+        # get full list of demand seasons from files
+        demand_seasons = sorted(
+            [
+                filename.split("_")[0]  # remove the _demand.json suffix
+                for filename in os.listdir(f"{config.DATA_DIR}/demand_stats/")
+                if filename[0] != "." and filename != "subjects.json"
+            ]
+        )
+    else:
+        course_seasons = seasons
+        demand_seasons = seasons
+
+    # Course listings.
+    if args.mode == "courses" or args.mode == "all":
+        print(f"Importing courses for season(s): {course_seasons}")
+        for season in course_seasons:
+            # Read the course listings, giving preference to freshly parsed over migrated ones.
+            parsed_courses_file = Path(
+                f"{config.DATA_DIR}/parsed_courses/{season}.json"
+            )
+
+            if parsed_courses_file.is_file():
+                with open(parsed_courses_file, "r") as f:
+                    parsed_course_info = ujson.load(f)
+            else:
+                # check migrated courses as a fallback
+                migrated_courses_file = Path(
+                    f"{config.DATA_DIR}/migrated_courses/{season}.json"
+                )
+
+                if not migrated_courses_file.is_file():
+                    print(
+                        f"Skipping season {season}: not found in parsed or migrated courses."
+                    )
+                    continue
+                with open(migrated_courses_file, "r") as f:
+                    parsed_course_info = ujson.load(f)
+
+            import_courses(tables, parsed_course_info)
+
+            #     with database.session_scope(database.Session) as session:
+            #         # tqdm.write(f"Importing {course_info}")
+            #         import_course(session, course_info)
+
+    # # Course demand.
+    # if args.mode == "demand" or args.mode == "all":
+    #     # Compute seasons.
+
+    #     print(f"Importing demand stats for seasons: {demand_seasons}")
+    #     for season in demand_seasons:
+
+    #         demand_file = Path(f"{config.DATA_DIR}/demand_stats/{season}_demand.json")
+
+    #         if not demand_file.is_file():
+    #             print(f"Skipping season {season}: demand statistics file not found.")
+    #             continue
+
+    #         with open(demand_file, "r") as f:
+    #             demand_stats = ujson.load(f)
+
+    #         for demand_info in tqdm(
+    #             demand_stats, desc=f"Importing demand stats for {season}"
+    #         ):
+    #             with database.session_scope(database.Session) as session:
+    #                 import_demand(session, season, demand_info)
+
+    # # Course evaluations.
+    # if args.mode == "evals" or args.mode == "all":
+    #     all_evals = [
+    #         filename
+    #         for filename in set(
+    #             os.listdir(f"{config.DATA_DIR}/previous_evals/")
+    #             + os.listdir(f"{config.DATA_DIR}/course_evals/")
+    #         )
+    #         if filename[0] != "."
+    #     ]
+
+    #     # Filter by seasons.
+    #     if seasons is None:
+    #         evals_to_import = sorted(list(all_evals))
+
+    #     else:
+    #         evals_to_import = sorted(
+    #             filename for filename in all_evals if filename.split("-")[0] in seasons
+    #         )
+
+    #     for filename in tqdm(evals_to_import, desc="Importing evaluations"):
+    #         # Read the evaluation, giving preference to current over previous.
+    #         current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
+
+    #         if current_evals_file.is_file():
+    #             with open(current_evals_file, "r") as f:
+    #                 evaluation = ujson.load(f)
+    #         else:
+    #             with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
+    #                 evaluation = ujson.load(f)
+
+    #         with database.session_scope(database.Session) as session:
+    #             # tqdm.write(f"Importing evaluation {evaluation}")
+    #             import_evaluation(session, evaluation)

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -367,6 +367,7 @@ def import_evaluations(merged_evaluations_info, listings):
         lambda x: x["comments"]
     )
 
+    # subset and explode
     evaluation_narratives = evaluation_narratives.loc[
         :, ["course_id", "question_code", "comment"]
     ]
@@ -393,6 +394,27 @@ def import_evaluations(merged_evaluations_info, listings):
     evaluation_ratings["rating"] = evaluation_ratings["ratings"].apply(
         lambda x: x["data"]
     )
+
+    # extract evaluation statistics
+    evaluations_statistics = evaluations.loc[
+        :, ["course_id", "enrollment", "extras"]
+    ].copy(deep=True)
+    evaluations_statistics["enrolled"] = evaluations_statistics["enrollment"].apply(
+        lambda x: x["enrolled"]
+    )
+    evaluations_statistics["responses"] = evaluations_statistics["enrollment"].apply(
+        lambda x: x["responses"]
+    )
+    evaluations_statistics["declined"] = evaluations_statistics["enrollment"].apply(
+        lambda x: x["declined"]
+    )
+    evaluations_statistics["no_response"] = evaluations_statistics["enrollment"].apply(
+        lambda x: x["no response"]
+    )
+
+    evaluations_statistics = evaluations_statistics.loc[
+        :, ["course_id", "enrolled", "responses", "declined", "no_response", "extras"]
+    ]
 
     return evaluations
 

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-
 from pathlib import Path
 
 import numpy as np

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.declarative import declarative_base
 
 from ferry import config, database
 from ferry.config import DATABASE_CONNECT_STRING
+from ferry.includes.computed import questions_computed, evaluation_statistics_computed
 from ferry.includes.importer import (
     copy_from_stringio,
     get_all_tables,
@@ -18,7 +19,6 @@ from ferry.includes.importer import (
     import_demand,
     import_evaluations,
 )
-from ferry.includes.computed import questions_computed
 from ferry.includes.tqdm import tqdm
 
 """
@@ -179,11 +179,16 @@ if __name__ == "__main__":
             seasons["season_code"].astype(str).apply(lambda x: x[:4]).astype(int)
         )
 
-        # ------------------------------
-        # Computing secondary attributes
-        # ------------------------------
+        # ----------------------------
+        # Compute secondary attributes
+        # ----------------------------
 
+        print("\n[Computing secondary attributes]")
+
+        print("Assigning question tags")
         evaluation_questions = questions_computed(evaluation_questions)
+        print("Computing average ratings by course")
+        evaluation_statistics = evaluation_statistics_computed(evaluation_statistics, evaluation_ratings, evaluation_questions)
 
         # -----------------------------
         # Output tables to disk as CSVs

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -18,6 +18,7 @@ from ferry.includes.importer import (
     import_demand,
     import_evaluations,
 )
+from ferry.includes.computed import questions_computed
 from ferry.includes.tqdm import tqdm
 
 """
@@ -178,6 +179,12 @@ if __name__ == "__main__":
             seasons["season_code"].astype(str).apply(lambda x: x[:4]).astype(int)
         )
 
+        # ------------------------------
+        # Computing secondary attributes
+        # ------------------------------
+
+        evaluation_questions = questions_computed(evaluation_questions)
+
         # -----------------------------
         # Output tables to disk as CSVs
         # -----------------------------
@@ -228,9 +235,9 @@ if __name__ == "__main__":
             csv_dir / "evaluation_statistics.csv", index_col=0
         )
 
-    # ------------------------
+    # --------------------------
     # Replace tables in database
-    # ------------------------
+    # --------------------------
     print("\n[Clearing database]")
 
     meta = MetaData(bind=database.Engine, reflect=True)

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -24,54 +24,30 @@ This script does not recalculate any computed values in the schema.
 """
 
 if __name__ == "__main__":
-    # allow the user to specify seasons (useful for testing and debugging)
-    parser = argparse.ArgumentParser(description="Import classes")
-    parser.add_argument(
-        "-s",
-        "--seasons",
-        nargs="+",
-        help="seasons to import (if empty, import all migrated+parsed courses)",
-        default=None,
-        required=False,
-    )
-    parser.add_argument(
-        "-m",
-        "--mode",
-        choices=["courses", "evals", "demand", "all"],
-        help="information to import: courses, evals, demand, or all (default)",
-        default="all",
-        required=False,
+
+    # ---------------------
+    # Get seasons to import
+    # ---------------------
+    # get full list of course seasons from files
+    course_seasons = sorted(
+        [
+            filename.split(".")[0]  # remove the .json extension
+            for filename in set(
+                os.listdir(f"{config.DATA_DIR}/migrated_courses/")
+                + os.listdir(f"{config.DATA_DIR}/parsed_courses/")
+            )
+            if filename[0] != "."
+        ]
     )
 
-    args = parser.parse_args()
-    seasons = args.seasons
-
-    # Course information.
-    if seasons is None:
-
-        # get full list of course seasons from files
-        course_seasons = sorted(
-            [
-                filename.split(".")[0]  # remove the .json extension
-                for filename in set(
-                    os.listdir(f"{config.DATA_DIR}/migrated_courses/")
-                    + os.listdir(f"{config.DATA_DIR}/parsed_courses/")
-                )
-                if filename[0] != "."
-            ]
-        )
-
-        # get full list of demand seasons from files
-        demand_seasons = sorted(
-            [
-                filename.split("_")[0]  # remove the _demand.json suffix
-                for filename in os.listdir(f"{config.DATA_DIR}/demand_stats/")
-                if filename[0] != "." and filename != "subjects.json"
-            ]
-        )
-    else:
-        course_seasons = seasons
-        demand_seasons = seasons
+    # get full list of demand seasons from files
+    demand_seasons = sorted(
+        [
+            filename.split("_")[0]  # remove the _demand.json suffix
+            for filename in os.listdir(f"{config.DATA_DIR}/demand_stats/")
+            if filename[0] != "." and filename != "subjects.json"
+        ]
+    )
 
     # ----------------------
     # Import course listings
@@ -186,5 +162,3 @@ if __name__ == "__main__":
         evaluation_statistics,
         evaluation_questions,
     ) = import_evaluations(merged_evaluations_info, listings)
-
-    # breakpoint()

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import psycopg2
 import ujson
 from sqlalchemy import MetaData
 from sqlalchemy.ext.declarative import declarative_base
@@ -177,33 +176,28 @@ if __name__ == "__main__":
 
     print("\n[Updating database]")
 
-    conn = psycopg2.connect(
-        host="localhost",
-        database="postgres",
-        user="postgres",
-        password="thisisapassword",
-    )
+    raw_conn = database.Engine.raw_connection()
 
     # insert new tables
     seasons = pd.DataFrame(course_seasons, columns=["season_code"], dtype=int)
     seasons["term"] = np.nan
     seasons["year"] = np.nan
-    copy_from_stringio(conn, seasons, "seasons")
+    copy_from_stringio(raw_conn, seasons, "seasons")
 
     # courses
-    copy_from_stringio(conn, courses, "courses")
-    copy_from_stringio(conn, listings, "listings")
-    copy_from_stringio(conn, professors, "professors")
-    copy_from_stringio(conn, course_professors, "course_professors")
+    copy_from_stringio(raw_conn, courses, "courses")
+    copy_from_stringio(raw_conn, listings, "listings")
+    copy_from_stringio(raw_conn, professors, "professors")
+    copy_from_stringio(raw_conn, course_professors, "course_professors")
 
     # demand statistics
-    copy_from_stringio(conn, demand_statistics, "demand_statistics")
+    copy_from_stringio(raw_conn, demand_statistics, "demand_statistics")
 
     # evaluations
-    copy_from_stringio(conn, evaluation_questions, "evaluation_questions")
-    copy_from_stringio(conn, evaluation_narratives, "evaluation_narratives")
-    copy_from_stringio(conn, evaluation_ratings, "evaluation_ratings")
-    copy_from_stringio(conn, evaluation_statistics, "evaluation_statistics")
+    copy_from_stringio(raw_conn, evaluation_questions, "evaluation_questions")
+    copy_from_stringio(raw_conn, evaluation_narratives, "evaluation_narratives")
+    copy_from_stringio(raw_conn, evaluation_ratings, "evaluation_ratings")
+    copy_from_stringio(raw_conn, evaluation_statistics, "evaluation_statistics")
 
     print("Committing new tables")
-    conn.commit()
+    raw_conn.commit()

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -1,21 +1,20 @@
 import argparse
+import contextlib
 import csv
 import os
 from io import StringIO
 from pathlib import Path
 
-
-import contextlib
 import d6tstack
 import numpy as np
 import pandas as pd
-import ujson
 import psycopg2
+import ujson
 from sqlalchemy import MetaData
-from ferry.config import DATABASE_CONNECT_STRING
 from sqlalchemy.ext.declarative import declarative_base
 
 from ferry import config, database
+from ferry.config import DATABASE_CONNECT_STRING
 from ferry.includes.importer import (
     get_all_tables,
     import_courses,

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -15,6 +15,7 @@ from ferry.includes.computed import (
     courses_computed,
     evaluation_statistics_computed,
     questions_computed,
+    professors_computed
 )
 from ferry.includes.importer import (
     copy_from_stringio,
@@ -196,6 +197,8 @@ if __name__ == "__main__":
         )
         print("Computing historical ratings for courses")
         courses = courses_computed(courses, listings, evaluation_statistics)
+        print("Computing ratings for professors")
+        professors = professors_computed(professors, course_professors, evaluation_statistics)
 
         # -----------------------------
         # Output tables to disk as CSVs

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -13,14 +13,13 @@ from sqlalchemy.ext.declarative import declarative_base
 from ferry import config, database
 from ferry.config import DATABASE_CONNECT_STRING
 from ferry.includes.importer import (
+    copy_from_stringio,
     get_all_tables,
     import_courses,
     import_demand,
     import_evaluations,
-    copy_from_stringio,
 )
 from ferry.includes.tqdm import tqdm
-
 
 """
 ================================================================

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -252,10 +252,19 @@ if __name__ == "__main__":
             csv_dir / "evaluation_statistics.csv", index_col=0
         )
 
+        # fix datatype assumptions by pandas
+        listings["section"] = listings["section"].astype(str)
+        evaluation_statistics["enrolled"] = evaluation_statistics["enrolled"].astype("Int64")
+        evaluation_statistics["responses"] = evaluation_statistics["responses"].astype("Int64")
+        evaluation_statistics["declined"] = evaluation_statistics["declined"].astype("Int64")
+        evaluation_statistics["no_response"] = evaluation_statistics["no_response"].astype("Int64")
+
     # --------------------------
     # Replace tables in database
     # --------------------------
     print("\n[Clearing database]")
+
+    print("Creating/clearing staging tables")
 
     meta = MetaData(bind=database.Engine, reflect=True)
     staging_tables = []
@@ -265,8 +274,7 @@ if __name__ == "__main__":
             args = []
             for column in table.columns:
                 args.append(column.copy())
-            for constraint in table.constraints:
-                args.append(constraint.copy())
+            # note that we exclude constraints from the staging tables
             staging_tables.append(
                 Table(
                     f"{table.name}_staged", table.metadata, extend_existing=True, *args
@@ -275,7 +283,7 @@ if __name__ == "__main__":
 
     meta.create_all(tables=staging_tables)
 
-    # drop old tables
+    # # drop old tables
     conn = database.Engine.connect()
     delete = conn.begin()
     for table in meta.sorted_tables:
@@ -307,5 +315,18 @@ if __name__ == "__main__":
     copy_from_stringio(raw_conn, evaluation_ratings, "evaluation_ratings_staged")
     copy_from_stringio(raw_conn, evaluation_statistics, "evaluation_statistics_staged")
 
-    print("Committing new tables")
+    print("Committing new staged tables")
     raw_conn.commit()
+
+    print("Replacing old tables with staged")
+
+    replace = conn.begin()
+    conn.execute("SET CONSTRAINTS ALL DEFERRED;")
+
+    # drop and update tables in reverse dependnecy order
+    for table in meta.sorted_tables[::-1]:
+        if not table.name.endswith("_staged"):
+            print(f"Updating table {table.name}")
+            conn.execute(f"DROP TABLE IF EXISTS {table.name};")
+            conn.execute(f'ALTER TABLE "{table.name}_staged" RENAME TO {table.name};')
+    replace.commit()

--- a/ferry/importer_pandas.py
+++ b/ferry/importer_pandas.py
@@ -362,7 +362,7 @@ if __name__ == "__main__":
         demand_seasons = seasons
 
     # Course listings.
-    print(f"Importing courses for season(s): {course_seasons.map(int)}")
+    print(f"Importing courses for season(s): {', '.join(course_seasons)}")
 
     merged_course_info = []
 
@@ -405,7 +405,7 @@ if __name__ == "__main__":
 
     merged_demand_info = []
 
-    print(f"Importing demand stats for seasons: {demand_seasons.map(int)}")
+    print(f"Importing demand stats for seasons: {', '.join(demand_seasons)}")
     for season in demand_seasons:
 
         demand_file = Path(f"{config.DATA_DIR}/demand_stats/{season}_demand.json")

--- a/ferry/includes/computed.py
+++ b/ferry/includes/computed.py
@@ -1,6 +1,8 @@
 import csv
+from typing import List
 
 import pandas as pd
+import ujson
 
 from ferry import config, database
 
@@ -9,8 +11,8 @@ with open(f"{config.RESOURCE_DIR}/question_tags.csv") as f:
     for question_code, tag in csv.reader(f):
         QUESTION_TAGS[question_code] = tag
 
-def questions_computed(evaluation_questions):
 
+def questions_computed(evaluation_questions):
     def assign_code(row):
 
         code = row["question_code"]
@@ -34,3 +36,47 @@ def questions_computed(evaluation_questions):
     evaluation_questions["tag"] = evaluation_questions.apply(assign_code, axis=1)
 
     return evaluation_questions
+
+def evaluation_statistics_computed(evaluation_statistics, evaluation_ratings, evaluation_questions):
+
+    question_code_map = dict(zip(evaluation_questions["question_code"],evaluation_questions["tag"]))
+
+    evaluation_ratings = evaluation_ratings.copy(deep=True)
+    evaluation_ratings["tag"] = evaluation_ratings["question_code"].apply(question_code_map.get)
+
+    def average_rating(ratings: List[int]) -> float:
+        if not ratings or not sum(ratings):
+            return None
+        agg = 0
+        for i, rating in enumerate(ratings):
+            multiplier = i + 1
+            agg += multiplier * rating
+        return agg / sum(ratings)
+
+    def average_by_course(tag, n_categories):
+
+        tagged_ratings = evaluation_ratings[evaluation_ratings["tag"]==tag].copy(deep=True)
+        rating_by_course = tagged_ratings.groupby("course_id")["rating"].apply(list)
+
+        # Aggregate responses across question variants.
+        rating_by_course = rating_by_course.apply(lambda data: [sum(x) for x in zip(*data)])
+
+        lengths_invalid = rating_by_course.apply(len) != n_categories
+
+        if any(lengths_invalid):
+            raise database.InvariantError(
+                f"Invalid workload responses, expected length of 5: {rating_by_course[lengths_invalid]}"
+            )
+
+        rating_by_course = rating_by_course.apply(average_rating)
+        rating_by_course = rating_by_course.to_dict()
+
+        return rating_by_course
+
+    overall_by_course = average_by_course("rating", 5)
+    workload_by_course = average_by_course("workload", 5)
+
+    evaluation_statistics["avg_rating"] = evaluation_statistics["course_id"].apply(overall_by_course.get)
+    evaluation_statistics["avg_workload"] = evaluation_statistics["course_id"].apply(workload_by_course.get)
+
+    return evaluation_statistics

--- a/ferry/includes/computed.py
+++ b/ferry/includes/computed.py
@@ -147,6 +147,7 @@ def courses_computed(courses, listings, evaluation_statistics):
 
     return courses
 
+
 def professors_computed(professors, course_professors, evaluation_statistics):
 
     course_professors = course_professors.copy(deep=True)
@@ -158,12 +159,21 @@ def professors_computed(professors, course_professors, evaluation_statistics):
     #     zip(evaluation_statistics["course_id"], evaluation_statistics["avg_workload"])
     # )
 
-    course_professors["average_rating"] = course_professors["course_id"].apply(course_to_overall.get)
+    course_professors["average_rating"] = course_professors["course_id"].apply(
+        course_to_overall.get
+    )
     # course_professors["average_workload"] = course_professors["course_id"].apply(course_to_workload.get)
 
-    rating_by_professor = course_professors.dropna(subset=["average_rating"]).groupby("professor_id")["average_rating"].mean().to_dict()
+    rating_by_professor = (
+        course_professors.dropna(subset=["average_rating"])
+        .groupby("professor_id")["average_rating"]
+        .mean()
+        .to_dict()
+    )
     # workload_by_professor = course_professors.dropna("average_workload").groupby("professor_id").mean().to_dict()
 
-    professors["average_rating"] = professors["professor_id"].apply(rating_by_professor.get)
+    professors["average_rating"] = professors["professor_id"].apply(
+        rating_by_professor.get
+    )
 
     return professors

--- a/ferry/includes/computed.py
+++ b/ferry/includes/computed.py
@@ -75,7 +75,7 @@ def evaluation_statistics_computed(
 
     """
 
-    # create local deep copy    
+    # create local deep copy
     evaluation_ratings = evaluation_ratings.copy(deep=True)
 
     # match tags to ratings
@@ -155,7 +155,7 @@ def courses_computed(courses, listings, evaluation_statistics):
 
     """
 
-    # create local deep copy    
+    # create local deep copy
     courses = courses.copy(deep=True)
 
     # map courses to codes and codes to courses for historical offerings
@@ -229,7 +229,7 @@ def professors_computed(professors, course_professors, evaluation_statistics):
 
     """
 
-    # create local deep copy    
+    # create local deep copy
     course_professors = course_professors.copy(deep=True)
 
     course_to_overall = dict(

--- a/ferry/includes/computed.py
+++ b/ferry/includes/computed.py
@@ -146,3 +146,24 @@ def courses_computed(courses, listings, evaluation_statistics):
     courses = courses.loc[:, get_table_columns(database.models.Course)]
 
     return courses
+
+def professors_computed(professors, course_professors, evaluation_statistics):
+
+    course_professors = course_professors.copy(deep=True)
+
+    course_to_overall = dict(
+        zip(evaluation_statistics["course_id"], evaluation_statistics["avg_rating"])
+    )
+    # course_to_workload = dict(
+    #     zip(evaluation_statistics["course_id"], evaluation_statistics["avg_workload"])
+    # )
+
+    course_professors["average_rating"] = course_professors["course_id"].apply(course_to_overall.get)
+    # course_professors["average_workload"] = course_professors["course_id"].apply(course_to_workload.get)
+
+    rating_by_professor = course_professors.dropna(subset=["average_rating"]).groupby("professor_id")["average_rating"].mean().to_dict()
+    # workload_by_professor = course_professors.dropna("average_workload").groupby("professor_id").mean().to_dict()
+
+    professors["average_rating"] = professors["professor_id"].apply(rating_by_professor.get)
+
+    return professors

--- a/ferry/includes/computed.py
+++ b/ferry/includes/computed.py
@@ -1,0 +1,36 @@
+import csv
+
+import pandas as pd
+
+from ferry import config, database
+
+QUESTION_TAGS = dict()
+with open(f"{config.RESOURCE_DIR}/question_tags.csv") as f:
+    for question_code, tag in csv.reader(f):
+        QUESTION_TAGS[question_code] = tag
+
+def questions_computed(evaluation_questions):
+
+    def assign_code(row):
+
+        code = row["question_code"]
+
+        # Remove these suffixes for tag resolution.
+        strip_suffixes = ["-YCWR", "-YXWR", "-SA"]
+
+        for suffix in strip_suffixes:
+            if code.endswith(suffix):
+                code = code[: -len(suffix)]
+                break
+
+        # Set the appropriate question tag.
+        try:
+            return QUESTION_TAGS[code]
+        except KeyError as e:
+            raise database.InvariantError(
+                f"No associated tag for question code {code} with text {row['question_text']}"
+            )
+
+    evaluation_questions["tag"] = evaluation_questions.apply(assign_code, axis=1)
+
+    return evaluation_questions

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -442,9 +442,6 @@ def import_evaluations(merged_evaluations_info, listings):
         axis=1,
     )
 
-    # remove cross-listed evaluations arbitrarily
-    evaluations = evaluations.drop_duplicates(subset=["course_id"], keep="first")
-
     # report number of evaluations with missing course codes
     nan_total = evaluations["course_id"].isna().sum()
     print(f"Removing {nan_total}/{len(evaluations)} evaluated courses without matches")
@@ -474,6 +471,11 @@ def import_evaluations(merged_evaluations_info, listings):
     )
     evaluation_narratives["comment"] = evaluation_narratives["narratives"].apply(
         lambda x: x["comments"]
+    )
+
+    # drop duplicate course_id-question_code combinations (cross-listings)
+    evaluation_narratives = evaluation_narratives.drop_duplicates(
+        ["course_id", "question_code"], keep="first"
     )
 
     evaluation_narratives["is_narrative"] = True
@@ -509,6 +511,11 @@ def import_evaluations(merged_evaluations_info, listings):
     )
     evaluation_ratings["rating"] = evaluation_ratings["ratings"].apply(
         lambda x: x["data"]
+    )
+
+    # drop duplicate course_id-question_code combinations (cross-listings)
+    evaluation_ratings = evaluation_ratings.drop_duplicates(
+        ["course_id", "question_code"], keep="first"
     )
 
     evaluation_ratings["is_narrative"] = False

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -162,6 +162,7 @@ def import_courses(merged_course_info, seasons: List[str]):
     listings = merged_course_info.copy(deep=True)
     listings["listing_id"] = range(len(listings))
     listings["course_id"] = listings["temp_course_id"].apply(temp_to_course_id.get)
+    listings["section"] = listings["section"].apply(lambda x: x if x == x else 0)
 
     print("Creating professors table")
     # initialize professors table

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -1,5 +1,4 @@
 import csv
-import psycopg2
 from collections import Counter
 from io import StringIO
 from itertools import combinations
@@ -7,6 +6,7 @@ from typing import Dict, List
 
 import numpy as np
 import pandas as pd
+import psycopg2
 import textdistance
 import ujson
 from sqlalchemy import inspect

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -294,6 +294,22 @@ def import_courses(merged_course_info, seasons: List[str]):
             lambda x: Counter(x).most_common(1)[0][0]
         )
 
+        ties = season_professors["matched_ids_aggregate"].apply(
+            lambda x: Counter(x).most_common(2)
+        )
+        ties = ties.apply(lambda x: False if len(x) != 2 else x[0][1] == x[1][1])
+
+        tied_professors = season_professors[ties]
+
+        def print_ties(row):
+            print(
+                f"Professor {row['name']} ({row['email']}, {row['ocs_id']}) has tied matches: ",
+                end="",
+            )
+            print(sorted(list(set(row["matched_ids_aggregate"]))))
+
+        tied_professors.apply(print_ties, axis=1)
+
         return professor_ids
 
     # course-professors junction table

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -1,25 +1,52 @@
 from collections import Counter
 from itertools import combinations
+from typing import List, Dict
 
 import numpy as np
 import pandas as pd
 import textdistance
 from sqlalchemy import inspect
 
-
 from ferry import config, database
-
 from ferry.includes.utils import invert_dict_of_lists, merge_overlapping
 
 
 def get_table(table: str):
+    """
+    Read one of the tables from the database
+    into Pandas dataframe (assuming SQL storage format)
+
+    Parameters
+    ----------
+    table: name of table to retrieve
+
+    Returns
+    -------
+    Pandas DataFrame
+
+    """
+
     return pd.read_sql_table(table, con=database.Engine)
 
 
-def get_all_tables(select_schemas: list):
+def get_all_tables(select_schemas: List[str]) -> Dict:
+    """
+    Get all the tables under given schemas as a dictionary
+    of Pandas dataframes
+
+    Parameters
+    ----------
+    select_schemas: schemas to retrieve tables for
+
+    Returns
+    -------
+    Dictionary of Pandas DataFrames
+
+    """
 
     tables = []
 
+    # inspect and get schema names
     inspector = inspect(database.Engine)
     schemas = inspector.get_schema_names()
 
@@ -36,7 +63,21 @@ def get_all_tables(select_schemas: list):
     return tables
 
 
-def import_courses(merged_course_info, seasons):
+def import_courses(merged_course_info, seasons: List[str]):
+    """
+    Import courses into Pandas DataFrames.
+
+    Parameters
+    ----------
+    merged_course_info: Pandas DataFrame of raw course information
+    from JSON files
+    seasons: list of seasons for sorting purposes
+
+    Returns
+    -------
+    courses, listings, course_professors, professors
+
+    """
 
     # seasons must be sorted in ascending order
 
@@ -254,7 +295,21 @@ def import_courses(merged_course_info, seasons):
     return courses, listings, course_professors, professors
 
 
-def import_demand(merged_demand_info, listings, seasons):
+def import_demand(merged_demand_info, listings, seasons: List[str]):
+    """
+    Import demand statistics into Pandas DataFrame.
+
+    Parameters
+    ----------
+    merged_demand_info: Pandas DataFrame of raw demand information
+    from JSON files
+    listings: listings DataFrame from import_courses
+
+    Returns
+    -------
+    demand_statistics
+
+    """
 
     demand_statistics = merged_demand_info.copy(deep=True)
 
@@ -342,6 +397,23 @@ def import_demand(merged_demand_info, listings, seasons):
 
 
 def import_evaluations(merged_evaluations_info, listings):
+    """
+    Import course evaluations into Pandas DataFrame.
+
+    Parameters
+    ----------
+    merged_evaluations_info: Pandas DataFrame of raw evaluation
+    information from JSON files
+    listings: listings DataFrame from import_courses
+
+    Returns
+    -------
+    evaluation_narratives,
+    evaluation_ratings,
+    evaluation_statistics,
+    evaluation_questions
+
+    """
 
     evaluations = merged_evaluations_info.copy(deep=True)
 

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -115,7 +115,7 @@ def import_courses(merged_course_info, seasons: List[str]):
     # group CRNs by season for cross-listing deduplication
     crns_by_season = merged_course_info.groupby("season_code")["crns"].apply(list)
     # convert CRN groups to sets for resolution
-    crns_by_season = crns_by_season.apply(lambda x: [set(y) for y in x])
+    crns_by_season = crns_by_season.apply(lambda x: [frozenset(y) for y in x])
     # resolve overlapping CRN sets
     crn_groups_by_season = crns_by_season.apply(merge_overlapping)
 
@@ -745,8 +745,7 @@ def copy_from_stringio(conn, df, table: str):
     # create in-memory buffer for DataFrame
     buffer = StringIO()
 
-    df.to_csv(
-        buffer,
+    csv_kwargs = dict(
         index_label="id",
         header=False,
         index=False,
@@ -755,6 +754,9 @@ def copy_from_stringio(conn, df, table: str):
         escapechar="\\",
         na_rep="NULL",
     )
+
+    df.to_csv(buffer, **csv_kwargs)
+
     buffer.seek(0)
 
     cursor = conn.cursor()

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -96,7 +96,8 @@ def import_courses(merged_course_info, seasons: List[str]):
     listings = merged_course_info.copy(deep=True)
     listings["listing_id"] = range(len(listings))
     listings["course_id"] = listings["temp_course_id"].apply(temp_to_course_id.get)
-    listings["section"] = listings["section"].apply(lambda x: x if x == x else 0)
+    listings["section"] = listings["section"].apply(lambda x: x if x == x else "0")
+    listings["section"] = listings["section"].fillna("0").astype(str)
 
     print("Creating professors table")
     # initialize professors table

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from itertools import combinations
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd
@@ -441,6 +441,9 @@ def import_evaluations(merged_evaluations_info, listings):
         ),
         axis=1,
     )
+
+    # remove cross-listed evaluations arbitrarily
+    evaluations = evaluations.drop_duplicates(subset=["course_id"], keep="first")
 
     # report number of evaluations with missing course codes
     nan_total = evaluations["course_id"].isna().sum()

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from sqlalchemy import inspect
+
+from ferry import config, database
+
+
+def get_table(table: str):
+    return pd.read_sql_table(table, con=database.Engine)
+
+
+def get_all_tables(select_schemas: list):
+
+    tables = []
+
+    inspector = inspect(database.Engine)
+    schemas = inspector.get_schema_names()
+
+    select_schemas = [x for x in schemas if x in select_schemas]
+
+    for schema in select_schemas:
+
+        schema_tables = inspector.get_table_names(schema=schema)
+
+        tables = tables + schema_tables
+
+    tables = {table: get_table(table) for table in tables}
+
+    return tables

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -1,7 +1,15 @@
+from collections import Counter
+from itertools import combinations
+
+import numpy as np
 import pandas as pd
+import textdistance
 from sqlalchemy import inspect
 
+
 from ferry import config, database
+
+from ferry.includes.utils import invert_dict_of_lists, merge_overlapping
 
 
 def get_table(table: str):
@@ -26,3 +34,501 @@ def get_all_tables(select_schemas: list):
     tables = {table: get_table(table) for table in tables}
 
     return tables
+
+
+def import_courses(merged_course_info, seasons):
+
+    # seasons must be sorted in ascending order
+
+    print("Aggregating cross-listings")
+    merged_course_info["season_code"] = merged_course_info["season_code"].astype(int)
+    merged_course_info["crn"] = merged_course_info["crn"].astype(int)
+    merged_course_info["crns"] = merged_course_info["crns"].apply(lambda x: map(int, x))
+
+    # group CRNs by season for cross-listing deduplication
+    crns_by_season = merged_course_info.groupby("season_code")["crns"].apply(list)
+    # convert CRN groups to sets for resolution
+    crns_by_season = crns_by_season.apply(lambda x: [set(y) for y in x])
+    # resolve overlapping CRN sets
+    crn_groups_by_season = crns_by_season.apply(merge_overlapping)
+
+    print("Mapping out cross-listings")
+    # map CRN groups to IDs
+    temp_course_ids_by_season = crns_by_season.apply(
+        lambda x: invert_dict_of_lists(dict(enumerate(x)))
+    )
+    temp_course_ids_by_season = temp_course_ids_by_season.to_dict()
+
+    # assign season-specific ID based on CRN group IDs
+    merged_course_info["season_course_id"] = merged_course_info.apply(
+        lambda row: temp_course_ids_by_season[row["season_code"]][row["crn"]], axis=1
+    )
+    # temporary string-based unique course identifier
+    merged_course_info["temp_course_id"] = merged_course_info.apply(
+        lambda x: f"{x['season_code']}_{x['season_course_id']}", axis=1
+    )
+
+    print("Creating courses table")
+    # initialize courses table
+    courses = merged_course_info.drop_duplicates(subset="temp_course_id").copy(
+        deep=True
+    )
+    courses["course_id"] = range(len(courses))
+
+    print("Creating listings table")
+    temp_to_course_id = dict(zip(courses["temp_course_id"], courses["course_id"]))
+
+    # initialize listings table
+    listings = merged_course_info.copy(deep=True)
+    listings["listing_id"] = range(len(listings))
+    listings["course_id"] = listings["temp_course_id"].apply(temp_to_course_id.get)
+
+    print("Creating professors table")
+    # initialize professors table
+    professors_prep = courses.loc[
+        :,
+        ["season_code", "course_id", "professors", "professor_emails", "professor_ids"],
+    ]
+
+    print("Resolving professor attributes")
+    professors_prep["professors"] = professors_prep["professors"].apply(
+        lambda x: x if x == x else []
+    )
+    professors_prep["professor_emails"] = professors_prep["professor_emails"].apply(
+        lambda x: x if x == x else []
+    )
+    professors_prep["professor_ids"] = professors_prep["professor_ids"].apply(
+        lambda x: x if x == x else []
+    )
+
+    professors_prep["professors_info"] = professors_prep[
+        ["professors", "professor_emails", "professor_ids"]
+    ].to_dict(orient="split")["data"]
+
+    def zip_professors_info(professors_info):
+
+        names, emails, ocs_ids = professors_info
+
+        names = list(filter(lambda x: x != "", names))
+        emails = list(filter(lambda x: x != "", emails))
+        ocs_ids = list(filter(lambda x: x != "", ocs_ids))
+
+        if len(names) == 0:
+            return []
+
+        # account for inconsistent lengths before zipping
+        if len(emails) != len(names):
+            emails = [None] * len(names)
+        if len(ocs_ids) != len(names):
+            ocs_ids = [None] * len(names)
+
+        return list(zip(names, emails, ocs_ids))
+
+    professors_prep["professors_info"] = professors_prep["professors_info"].apply(
+        zip_professors_info
+    )
+
+    professors_prep = professors_prep[professors_prep["professors_info"].apply(len) > 0]
+
+    # expand courses with multiple professors
+    professors_prep = professors_prep.loc[
+        :, ["season_code", "course_id", "professors_info"]
+    ].explode("professors_info")
+    professors_prep = professors_prep.reset_index(drop=True)
+
+    # expand professor info columns
+    professors_prep[["name", "email", "ocs_id"]] = pd.DataFrame(
+        professors_prep["professors_info"].tolist(), index=professors_prep.index
+    )
+
+    print("Constructing professors table in chronological order")
+    professors = pd.DataFrame(columns=["professor_id", "name", "email", "ocs_id"])
+
+    professors_by_season = professors_prep.groupby("season_code")
+
+    def get_professor_identifiers(professors):
+
+        names_ids = (
+            professors.dropna(subset=["name"])
+            .groupby("name")["professor_id"]
+            .apply(list)
+            .to_dict()
+        )
+        emails_ids = (
+            professors.dropna(subset=["email"])
+            .groupby("email")["professor_id"]
+            .apply(list)
+            .to_dict()
+        )
+        ocs_ids = (
+            professors.dropna(subset=["ocs_id"])
+            .groupby("ocs_id")["professor_id"]
+            .apply(list)
+            .to_dict()
+        )
+
+        return names_ids, emails_ids, ocs_ids
+
+    def match_professors(season_professors, professors):
+
+        names_ids, emails_ids, ocs_ids = get_professor_identifiers(professors)
+
+        # get ID matches by field
+        season_professors["name_matched_ids"] = season_professors["name"].apply(
+            lambda x: names_ids.get(x, [])
+        )
+        season_professors["email_matched_ids"] = season_professors["email"].apply(
+            lambda x: emails_ids.get(x, [])
+        )
+        season_professors["ocs_matched_ids"] = season_professors["ocs_id"].apply(
+            lambda x: ocs_ids.get(x, [])
+        )
+
+        season_professors["matched_ids_aggregate"] = (
+            season_professors["name_matched_ids"]
+            + season_professors["email_matched_ids"]
+            + season_professors["ocs_matched_ids"]
+        )
+
+        season_professors["matched_ids_aggregate"] = season_professors[
+            "matched_ids_aggregate"
+        ].apply(lambda x: x if len(x) > 0 else [np.nan])
+
+        professor_ids = season_professors["matched_ids_aggregate"].apply(
+            lambda x: Counter(x).most_common(1)[0][0]
+        )
+
+        return professor_ids
+
+    course_professors = []
+
+    # build professors table in order of seasons
+    for season in seasons:
+
+        season_professors = professors_by_season.get_group(int(season)).copy(deep=True)
+
+        # first-pass
+        season_professors["professor_id"] = match_professors(
+            season_professors, professors
+        )
+
+        professors_update = season_professors.drop_duplicates(
+            subset=["name", "email", "ocs_id"], keep="first"
+        ).copy(deep=True)
+
+        new_professors = professors_update[professors_update["professor_id"].isna()]
+
+        max_professor_id = max(list(professors["professor_id"]) + [0])
+        new_professor_ids = pd.Series(
+            range(max_professor_id + 1, max_professor_id + len(new_professors) + 1),
+            index=new_professors.index,
+            dtype=np.float64,
+        )
+        professors_update["professor_id"].update(new_professor_ids)
+        professors_update["professor_id"] = professors_update["professor_id"].astype(
+            int
+        )
+        professors_update = professors_update.drop_duplicates(
+            subset=["professor_id"], keep="first"
+        )
+        professors_update = professors_update.set_index("professor_id")
+
+        professors = professors.set_index("professor_id", drop=True)
+        professors = professors_update[professors.columns].combine_first(professors)
+        professors = professors.reset_index(drop=False)
+
+        # second-pass
+        season_professors["professor_id"] = match_professors(
+            season_professors, professors
+        )
+
+        course_professors.append(season_professors[["course_id", "professor_id"]])
+
+    course_professors = pd.concat(course_professors, axis=0, sort=True)
+
+    print(f"Total courses: {len(courses)}")
+    print(f"Total listings: {len(listings)}")
+    print(f"Total course-professors: {len(course_professors)}")
+    print(f"Total professors: {len(professors)}")
+
+    return courses, listings, course_professors, professors
+
+
+def import_demand(merged_demand_info, listings, seasons):
+
+    demand_statistics = merged_demand_info.copy(deep=True)
+
+    # construct outer season grouping
+    season_code_to_course_id = listings[
+        ["season_code", "course_code", "course_id"]
+    ].groupby("season_code")
+
+    # construct inner course_code to course_id mapping
+    season_code_to_course_id = season_code_to_course_id.apply(
+        lambda x: x[["course_code", "course_id"]]
+        .groupby("course_code")["course_id"]
+        .apply(list)
+        .to_dict()
+    )
+
+    # cast outer season mapping to dictionary
+    season_code_to_course_id = season_code_to_course_id.to_dict()
+
+    def match_demand_to_courses(row):
+        season_code = int(row["season_code"])
+
+        course_ids = [
+            season_code_to_course_id.get(season_code, {}).get(x, None)
+            for x in row["codes"]
+        ]
+
+        course_ids = [set(x) for x in course_ids if x is not None]
+
+        if course_ids == []:
+            return []
+
+        # union all course IDs
+        course_ids = set.union(*course_ids)
+        course_ids = sorted(list(course_ids))
+
+        return course_ids
+
+    demand_statistics["course_id"] = demand_statistics.apply(
+        match_demand_to_courses, axis=1
+    )
+
+    demand_statistics = demand_statistics.loc[
+        demand_statistics["course_id"].apply(len) > 0, :
+    ]
+
+    def date_to_int(date):
+        month, day = date.split("/")
+
+        month = int(month)
+        day = int(day)
+
+        return month * 100 + day
+
+    def get_most_recent_demand(row):
+
+        sorted_demand = list(row["overall_demand"].items())
+        sorted_demand.sort(key=lambda x: date_to_int(x[0]))
+        latest_demand_date, latest_demand = sorted_demand[-1]
+
+        return [latest_demand, latest_demand_date]
+
+    # get most recent demand date
+    latest = demand_statistics.apply(get_most_recent_demand, axis=1)
+    demand_statistics[["latest_demand", "latest_demand_date"]] = pd.DataFrame(
+        latest.values.tolist()
+    )
+
+    # expand course_id list to one per row
+    demand_statistics = demand_statistics.explode("course_id")
+
+    # rename demand JSON column to match database
+    demand_statistics = demand_statistics.rename(
+        {"overall_demand": "demand"}, axis="columns"
+    )
+
+    # return columns of interest
+    demand_statistics = demand_statistics.loc[
+        :, ["course_id", "latest_demand", "latest_demand_date", "demand"]
+    ]
+
+    print(f"Total demand statistics: {len(demand_statistics)}")
+
+    return demand_statistics
+
+
+def import_evaluations(merged_evaluations_info, listings):
+
+    evaluations = merged_evaluations_info.copy(deep=True)
+
+    # construct outer season grouping
+    season_crn_to_course_id = listings[["season_code", "course_id", "crn"]].groupby(
+        "season_code"
+    )
+
+    # construct inner course_code to course_id mapping
+    season_crn_to_course_id = season_crn_to_course_id.apply(
+        lambda x: x[["crn", "course_id"]].set_index("crn")["course_id"].to_dict()
+    )
+
+    # cast outer season mapping to dictionary
+    season_crn_to_course_id = season_crn_to_course_id.to_dict()
+
+    # convert evaluation season and crn types for matching
+    evaluations["season"] = evaluations["season"].astype(int)
+    evaluations["crn_code"] = evaluations["crn_code"].astype(int)
+
+    # find course codes for evaluations
+    evaluations["course_id"] = evaluations.apply(
+        lambda row: season_crn_to_course_id.get(row["season"], {}).get(
+            row["crn_code"], None
+        ),
+        axis=1,
+    )
+
+    # report number of evaluations with missing course codes
+    nan_total = evaluations["course_id"].isna().sum()
+    print(f"Removing {nan_total}/{len(evaluations)} evaluated courses without matches")
+
+    # remove evaluations with missing course codes
+    evaluations = evaluations.dropna(subset=["course_id"], axis=0)
+    evaluations["course_id"] = evaluations["course_id"].astype(int)
+
+    evaluation_questions = []
+
+    # extract evaluation narratives
+    evaluation_narratives = evaluations[evaluations["narratives"].apply(len) > 0].copy(
+        deep=True
+    )
+
+    evaluation_narratives = evaluation_narratives.loc[
+        :, ["course_id", "narratives", "season"]
+    ]
+
+    # expand each question into own column
+    evaluation_narratives = evaluation_narratives.explode("narratives")
+    evaluation_narratives["question_code"] = evaluation_narratives["narratives"].apply(
+        lambda x: x["question_id"]
+    )
+    evaluation_narratives["question_text"] = evaluation_narratives["narratives"].apply(
+        lambda x: x["question_text"]
+    )
+    evaluation_narratives["comment"] = evaluation_narratives["narratives"].apply(
+        lambda x: x["comments"]
+    )
+
+    evaluation_narratives["is_narrative"] = True
+    evaluation_questions.append(
+        evaluation_narratives.loc[
+            :, ["season", "question_code", "is_narrative", "question_text"]
+        ].copy(deep=True)
+    )
+
+    # subset and explode
+    evaluation_narratives = evaluation_narratives.loc[
+        :, ["course_id", "question_code", "comment"]
+    ]
+    evaluation_narratives = evaluation_narratives.explode("comment")
+    evaluation_narratives = evaluation_narratives.reset_index(drop=True)
+
+    # extract evaluation ratings
+    evaluation_ratings = evaluations[evaluations["ratings"].apply(len) > 0].copy(
+        deep=True
+    )
+
+    evaluation_ratings = evaluation_ratings.loc[:, ["course_id", "ratings", "season"]]
+    evaluation_ratings = evaluation_ratings.explode("ratings")
+
+    evaluation_ratings["question_code"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["question_id"]
+    )
+    evaluation_ratings["question_text"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["question_text"]
+    )
+    evaluation_ratings["options"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["options"]
+    )
+    evaluation_ratings["rating"] = evaluation_ratings["ratings"].apply(
+        lambda x: x["data"]
+    )
+
+    evaluation_ratings["is_narrative"] = False
+    evaluation_questions.append(
+        evaluation_ratings.loc[
+            :, ["question_code", "is_narrative", "question_text", "options", "season"]
+        ].copy(deep=True)
+    )
+
+    # extract evaluation statistics
+    evaluation_statistics = evaluations.loc[
+        :, ["course_id", "enrollment", "extras"]
+    ].copy(deep=True)
+    evaluation_statistics["enrolled"] = evaluation_statistics["enrollment"].apply(
+        lambda x: x["enrolled"]
+    )
+    evaluation_statistics["responses"] = evaluation_statistics["enrollment"].apply(
+        lambda x: x["responses"]
+    )
+    evaluation_statistics["declined"] = evaluation_statistics["enrollment"].apply(
+        lambda x: x["declined"]
+    )
+    evaluation_statistics["no_response"] = evaluation_statistics["enrollment"].apply(
+        lambda x: x["no response"]
+    )
+
+    evaluation_statistics = evaluation_statistics.loc[
+        :, ["course_id", "enrolled", "responses", "declined", "no_response", "extras"]
+    ]
+
+    evaluation_questions = pd.concat(evaluation_questions, axis=0, sort=True)
+    evaluation_questions = evaluation_questions.reset_index(drop=True)
+
+    # consistency checks
+    print("Checking question text consistency")
+    text_by_code = evaluation_questions.groupby("question_code")["question_text"].apply(
+        set
+    )
+
+    # focus on question texts with multiple variations
+    text_by_code = text_by_code[text_by_code.apply(len) > 1]
+    max_diff_texts = max(text_by_code.apply(len))
+    print(f"Maximum number of different texts per question code: {max_diff_texts}")
+
+    def min_pairwise_distance(texts):
+
+        pairs = combinations(texts, 2)
+        distances = [textdistance.levenshtein.distance(*pair) for pair in pairs]
+
+        return max(distances)
+
+    distances_by_code = text_by_code.apply(min_pairwise_distance)
+    max_all_distances = max(distances_by_code)
+
+    print(f"Maximum text divergence within codes: {max_all_distances}")
+
+    if not all(distances_by_code < 32):
+
+        inconsistent_codes = distances_by_code[distances_by_code >= 32]
+        inconsistent_codes = list(inconsistent_codes.index)
+        inconsistent_codes = ", ".join(inconsistent_codes)
+
+        raise database.InvariantError(
+            f"Error: question codes {inconsistent_codes} have divergent texts"
+        )
+
+    print("Checking question type (narrative/rating) consistency")
+    is_narrative_by_code = evaluation_questions.groupby("question_code")[
+        "is_narrative"
+    ].apply(set)
+
+    if not all(is_narrative_by_code.apply(len) == 1):
+        inconsistent_codes = is_narrative_by_code[is_narrative_by_code.apply(len) != 1]
+        inconsistent_codes = list(inconsistent_codes.index)
+        inconsistent_codes = ", ".join(inconsistent_codes)
+        raise database.InvariantError(
+            f"Error: question codes {inconsistent_codes} have both narratives and ratings"
+        )
+
+    # deduplicate questions and keep most recent
+    evaluation_questions = evaluation_questions.sort_values(
+        by="season", ascending=False
+    )
+    evaluation_questions = evaluation_questions.drop_duplicates(
+        subset=["question_code"], keep="first"
+    )
+
+    print(f"Total evaluation narratives: {len(evaluation_narratives)}")
+    print(f"Total evaluation ratings: {len(evaluation_ratings)}")
+    print(f"Total evaluation statistics: {len(evaluation_statistics)}")
+    print(f"Total evaluation questions: {len(evaluation_questions)}")
+
+    return (
+        evaluation_narratives,
+        evaluation_ratings,
+        evaluation_statistics,
+        evaluation_questions,
+    )

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -12,81 +12,15 @@ import ujson
 from sqlalchemy import inspect
 
 from ferry import config, database
-from ferry.includes.utils import invert_dict_of_lists, merge_overlapping
+from ferry.includes.utils import (
+    get_table_columns,
+    invert_dict_of_lists,
+    merge_overlapping,
+)
 
 
 class DatabaseError(Exception):
     print
-
-
-def get_table(table: str):
-    """
-    Read one of the tables from the database
-    into Pandas dataframe (assuming SQL storage format)
-
-    Parameters
-    ----------
-    table: name of table to retrieve
-
-    Returns
-    -------
-    Pandas DataFrame
-
-    """
-
-    return pd.read_sql_table(table, con=database.Engine)
-
-
-def get_table_columns(table):
-    """
-    Get column names of a table, where table is
-    a SQLalchemy model (e.g. ferry.database.models.Course)
-
-    Parameters
-    ----------
-    table: name of table to retrieve
-
-    Returns
-    -------
-    Pandas DataFrame
-
-    """
-
-    return [column.key for column in table.__table__.columns]
-
-
-def get_all_tables(select_schemas: List[str]) -> Dict:
-    """
-    Get all the tables under given schemas as a dictionary
-    of Pandas dataframes
-
-    Parameters
-    ----------
-    select_schemas: schemas to retrieve tables for
-
-    Returns
-    -------
-    Dictionary of Pandas DataFrames
-
-    """
-
-    tables = []
-
-    # inspect and get schema names
-    inspector = inspect(database.Engine)
-    schemas = inspector.get_schema_names()
-
-    select_schemas = [x for x in schemas if x in select_schemas]
-
-    for schema in select_schemas:
-
-        schema_tables = inspector.get_table_names(schema=schema)
-
-        tables = tables + schema_tables
-
-    tables = {table: get_table(table) for table in tables}
-
-    return tables
 
 
 def import_courses(merged_course_info, seasons: List[str]):

--- a/ferry/includes/utils.py
+++ b/ferry/includes/utils.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from itertools import combinations
-from typing import Dict, Iterable, List, Tuple, FrozenSet, TypeVar
+from typing import Dict, FrozenSet, Iterable, List, Tuple, TypeVar
 
 import networkx
 

--- a/ferry/includes/utils.py
+++ b/ferry/includes/utils.py
@@ -17,6 +17,10 @@ def merge_overlapping(sets):
 
     """
 
+    # deduplicate sets to improve performance
+    sets = set([frozenset(x) for x in sets])
+    sets = [set(x) for x in list(sets)]
+
     is_merged = True
 
     while is_merged:

--- a/ferry/includes/utils.py
+++ b/ferry/includes/utils.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from itertools import combinations
-from typing import List, Set, Dict
+from typing import Dict, List, Set
 
 import networkx
 

--- a/ferry/includes/utils.py
+++ b/ferry/includes/utils.py
@@ -45,6 +45,17 @@ def merge_overlapping(sets):
     return sets
 
 
+def invert_dict_of_lists(d):
+
+    inverted = {}
+
+    for k, v in d.items():
+        for x in v:
+            inverted[x] = k
+
+    return inverted
+
+
 def elementwise_sum(a, b):
     """
     Given two lists of equal length, return

--- a/ferry/includes/utils.py
+++ b/ferry/includes/utils.py
@@ -1,10 +1,11 @@
 from functools import reduce
 from itertools import combinations
+from typing import List, Set, Dict
 
 import networkx
 
 
-def merge_overlapping(sets):
+def merge_overlapping(sets: List[Set]) -> List:
     """
     Given a list of sets, merge sets with
     a nonempty intersection until all sets
@@ -35,7 +36,22 @@ def merge_overlapping(sets):
     return merged
 
 
-def invert_dict_of_lists(d):
+def invert_dict_of_lists(d: Dict) -> Dict:
+    """
+    Given a dictionary mapping x -> [a, b, c],
+    invert such that it now maps all a, b, c -> x.
+    If same value in multiple keys, then inverted
+    dictionary overwrites arbitrarily.
+
+    Parameters
+    ----------
+    d: input dictionary of lists
+
+    Returns
+    -------
+    inverted: output inverted dictionary
+
+    """
 
     inverted = {}
 
@@ -46,7 +62,7 @@ def invert_dict_of_lists(d):
     return inverted
 
 
-def elementwise_sum(a, b):
+def elementwise_sum(a: List, b: List) -> List:
     """
     Given two lists of equal length, return
     a list of elementwise sums
@@ -69,7 +85,7 @@ def elementwise_sum(a, b):
     return [sum(x) for x in zip(a, b)]
 
 
-def category_average(categories):
+def category_average(categories: List):
     """
     Given a list-like of n category counts,
     aggregate and return the average where each
@@ -77,7 +93,7 @@ def category_average(categories):
 
     Parameters
     ----------
-    categories: list-like of lists
+    categories: list-like
         categories
 
     Returns

--- a/ferry/includes/utils.py
+++ b/ferry/includes/utils.py
@@ -1,4 +1,7 @@
 from functools import reduce
+from itertools import combinations
+
+import networkx
 
 
 def merge_overlapping(sets):
@@ -19,34 +22,17 @@ def merge_overlapping(sets):
 
     # deduplicate sets to improve performance
     sets = set([frozenset(x) for x in sets])
-    sets = [set(x) for x in list(sets)]
+    sets = list(sets)
 
-    is_merged = True
+    g = networkx.Graph()
+    for sub_set in sets:
+        for edge in combinations(list(sub_set), 2):
+            g.add_edge(*edge)
 
-    while is_merged:
+    merged = networkx.connected_components(g)
+    merged = [set(x) for x in merged]
 
-        is_merged = False
-        temp_merged = []
-
-        while len(sets) > 0:
-
-            common, rest = sets[0], sets[1:]
-            sets = []
-
-            for x in rest:
-
-                if x.isdisjoint(common):
-                    sets.append(x)
-
-                else:
-                    is_merged = True
-                    common |= x
-
-            temp_merged.append(common)
-
-        sets = temp_merged
-
-    return sets
+    return merged
 
 
 def invert_dict_of_lists(d):

--- a/ferry/includes/utils.py
+++ b/ferry/includes/utils.py
@@ -1,11 +1,11 @@
 from functools import reduce
 from itertools import combinations
-from typing import Dict, List, Set
+from typing import Dict, Iterable, List, Tuple, FrozenSet, TypeVar
 
 import networkx
 
 
-def merge_overlapping(sets: List[Set]) -> List:
+def merge_overlapping(sets: List[FrozenSet]) -> List:
     """
     Given a list of sets, merge sets with
     a nonempty intersection until all sets
@@ -22,8 +22,7 @@ def merge_overlapping(sets: List[Set]) -> List:
     """
 
     # deduplicate sets to improve performance
-    sets = set([frozenset(x) for x in sets])
-    sets = list(sets)
+    sets = list(set(sets))
 
     g = networkx.Graph()
     for sub_set in sets:
@@ -62,7 +61,10 @@ def invert_dict_of_lists(d: Dict) -> Dict:
     return inverted
 
 
-def elementwise_sum(a: List, b: List) -> List:
+N = TypeVar("N", int, float)
+
+
+def elementwise_sum(a: List[N], b: List[N]) -> List[N]:
     """
     Given two lists of equal length, return
     a list of elementwise sums
@@ -85,7 +87,7 @@ def elementwise_sum(a: List, b: List) -> List:
     return [sum(x) for x in zip(a, b)]
 
 
-def category_average(categories: List):
+def category_average(categories: List[int]) -> Tuple[float, int]:
     """
     Given a list-like of n category counts,
     aggregate and return the average where each
@@ -104,12 +106,7 @@ def category_average(categories: List):
     """
 
     if len(categories) == 0:
-        return None, None
-
-    categories = reduce(elementwise_sum, categories)
-
-    if sum(categories) == 0:
-        return None, None
+        return 0, -1
 
     categories_sum = sum([categories[i] * (i + 1) for i in range(len(categories))])
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -124,6 +124,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "decorator"
+version = "4.4.2"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+
+[[package]]
 name = "diskcache"
 version = "4.1.0"
 description = "Disk Cache -- Disk and file backed persistent cache."
@@ -145,6 +153,7 @@ spacy = ">=2.3.0,<2.4.0"
 [package.source]
 type = "url"
 url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz"
+
 [[package]]
 name = "eralchemy"
 version = "1.2.10"
@@ -251,6 +260,30 @@ description = "Experimental type system extensions for programs checked with the
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "networkx"
+version = "2.5"
+description = "Python package for creating and manipulating graphs and networks"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+decorator = ">=4.3.0"
+
+[package.extras]
+all = ["numpy", "scipy", "pandas", "matplotlib", "pygraphviz", "pydot", "pyyaml", "lxml", "pytest"]
+gdal = ["gdal"]
+lxml = ["lxml"]
+matplotlib = ["matplotlib"]
+numpy = ["numpy"]
+pandas = ["pandas"]
+pydot = ["pydot"]
+pygraphviz = ["pygraphviz"]
+pytest = ["pytest"]
+pyyaml = ["pyyaml"]
+scipy = ["scipy"]
 
 [[package]]
 name = "nltk"
@@ -760,7 +793,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "12a87af81597e922846a5befed69ab47d75614154f60f5d5861973fed53516ab"
+content-hash = "5bd68f87365ce9aeff914ea06f7b1e3c1d7560fced8a85e3bc1e7fc77505dbcd"
 
 [metadata.files]
 annoy = [
@@ -834,6 +867,10 @@ cymem = [
     {file = "cymem-2.0.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:85b9364e099426bd7f445a7705aad87bf6dbb71d79e3802dd8ca14e181d38a33"},
     {file = "cymem-2.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd24848fbd75b17bab06408da6c029ba7cc615bd9e4a1f755fb3a090025fb922"},
     {file = "cymem-2.0.3.tar.gz", hash = "sha256:5083b2ab5fe13ced094a82e0df465e2dbbd9b1c013288888035e24fd6eb4ed01"},
+]
+decorator = [
+    {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
+    {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
 ]
 diskcache = [
     {file = "diskcache-4.1.0-py2.py3-none-any.whl", hash = "sha256:69b253a6ffe95bb4bafb483b97c24fca3c2c6c47b82e92b36486969a7e80d47d"},
@@ -963,6 +1000,10 @@ murmurhash = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+networkx = [
+    {file = "networkx-2.5-py3-none-any.whl", hash = "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"},
+    {file = "networkx-2.5.tar.gz", hash = "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602"},
 ]
 nltk = [
     {file = "nltk-3.5.zip", hash = "sha256:845365449cd8c5f9731f7cb9f8bd6fd0767553b9d53af9eb1b3abf7700936b35"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -153,7 +153,6 @@ spacy = ">=2.3.0,<2.4.0"
 [package.source]
 type = "url"
 url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz"
-
 [[package]]
 name = "eralchemy"
 version = "1.2.10"
@@ -332,7 +331,7 @@ numpy = ">=1.7"
 
 [[package]]
 name = "numpy"
-version = "1.19.2"
+version = "1.19.3"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -372,7 +371,7 @@ python-versions = "*"
 
 [[package]]
 name = "plotly"
-version = "4.11.0"
+version = "4.12.0"
 description = "An open-source, interactive data visualization library for Python"
 category = "dev"
 optional = false
@@ -416,11 +415,14 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
 name = "pybind11"
-version = "2.5.0"
+version = "2.6.0"
 description = "Seamless operability between C++11 and Python"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = "!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,>=2.7"
+
+[package.extras]
+global = ["pybind11-global (2.6.0)"]
 
 [[package]]
 name = "pygraphviz"
@@ -466,7 +468,7 @@ python-versions = "*"
 
 [[package]]
 name = "regex"
-version = "2020.10.15"
+version = "2020.10.28"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = false
@@ -702,7 +704,7 @@ python-versions = "*"
 
 [[package]]
 name = "tqdm"
-version = "4.50.2"
+version = "4.51.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = false
@@ -1056,32 +1058,40 @@ numexpr = [
     {file = "numexpr-2.7.1.tar.gz", hash = "sha256:b0d239d9827e1bcee08344fd05835823bc60aff97232e35a928214d03ff802b1"},
 ]
 numpy = [
-    {file = "numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b594f76771bc7fc8a044c5ba303427ee67c17a09b36e1fa32bde82f5c419d17a"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e6ddbdc5113628f15de7e4911c02aed74a4ccff531842c583e5032f6e5a179bd"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:4339741994c775396e1a274dba3609c69ab0f16056c1077f18979bec2a2c2e6e"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c"},
-    {file = "numpy-1.19.2-cp36-cp36m-win32.whl", hash = "sha256:9a3001248b9231ed73894c773142658bab914645261275f675d86c290c37f66d"},
-    {file = "numpy-1.19.2-cp36-cp36m-win_amd64.whl", hash = "sha256:967c92435f0b3ba37a4257c48b8715b76741410467e2bdb1097e8391fccfae15"},
-    {file = "numpy-1.19.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d526fa58ae4aead839161535d59ea9565863bb0b0bdb3cc63214613fb16aced4"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:eb25c381d168daf351147713f49c626030dcff7a393d5caa62515d415a6071d8"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:62139af94728d22350a571b7c82795b9d59be77fc162414ada6c8b6a10ef5d02"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:0c66da1d202c52051625e55a249da35b31f65a81cb56e4c69af0dfb8fb0125bf"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2117536e968abb7357d34d754e3733b0d7113d4c9f1d921f21a3d96dec5ff716"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:54045b198aebf41bf6bf4088012777c1d11703bf74461d70cd350c0af2182e45"},
-    {file = "numpy-1.19.2-cp37-cp37m-win32.whl", hash = "sha256:aba1d5daf1144b956bc87ffb87966791f5e9f3e1f6fab3d7f581db1f5b598f7a"},
-    {file = "numpy-1.19.2-cp37-cp37m-win_amd64.whl", hash = "sha256:addaa551b298052c16885fc70408d3848d4e2e7352de4e7a1e13e691abc734c1"},
-    {file = "numpy-1.19.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:58d66a6b3b55178a1f8a5fe98df26ace76260a70de694d99577ddeab7eaa9a9d"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:59f3d687faea7a4f7f93bd9665e5b102f32f3fa28514f15b126f099b7997203d"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cebd4f4e64cfe87f2039e4725781f6326a61f095bc77b3716502bed812b385a9"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c35a01777f81e7333bcf276b605f39c872e28295441c265cd0c860f4b40148c1"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d7ac33585e1f09e7345aa902c281bd777fdb792432d27fca857f39b70e5dd31c"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:04c7d4ebc5ff93d9822075ddb1751ff392a4375e5885299445fcebf877f179d5"},
-    {file = "numpy-1.19.2-cp38-cp38-win32.whl", hash = "sha256:51ee93e1fac3fe08ef54ff1c7f329db64d8a9c5557e6c8e908be9497ac76374b"},
-    {file = "numpy-1.19.2-cp38-cp38-win_amd64.whl", hash = "sha256:1669ec8e42f169ff715a904c9b2105b6640f3f2a4c4c2cb4920ae8b2785dac65"},
-    {file = "numpy-1.19.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:0bfd85053d1e9f60234f28f63d4a5147ada7f432943c113a11afcf3e65d9d4c8"},
-    {file = "numpy-1.19.2.zip", hash = "sha256:0d310730e1e793527065ad7dde736197b705d0e4c9999775f212b03c44a8484c"},
+    {file = "numpy-1.19.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:942d2cdcb362739908c26ce8dd88db6e139d3fa829dd7452dd9ff02cba6b58b2"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:efd656893171bbf1331beca4ec9f2e74358fc732a2084f664fd149cc4b3441d2"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1a307bdd3dd444b1d0daa356b5f4c7de2e24d63bdc33ea13ff718b8ec4c6a268"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9d08d84bb4128abb9fbd9f073e5c69f70e5dab991a9c42e5b4081ea5b01b5db0"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7197ee0a25629ed782c7bd01871ee40702ffeef35bc48004bc2fdcc71e29ba9d"},
+    {file = "numpy-1.19.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:8edc4d687a74d0a5f8b9b26532e860f4f85f56c400b3a98899fc44acb5e27add"},
+    {file = "numpy-1.19.3-cp36-cp36m-win32.whl", hash = "sha256:522053b731e11329dd52d258ddf7de5288cae7418b55e4b7d32f0b7e31787e9d"},
+    {file = "numpy-1.19.3-cp36-cp36m-win_amd64.whl", hash = "sha256:eefc13863bf01583a85e8c1121a901cc7cb8f059b960c4eba30901e2e6aba95f"},
+    {file = "numpy-1.19.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ff88bcf1872b79002569c63fe26cd2cda614e573c553c4d5b814fb5eb3d2822"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e080087148fd70469aade2abfeadee194357defd759f9b59b349c6192aba994c"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:50f68ebc439821b826823a8da6caa79cd080dee2a6d5ab9f1163465a060495ed"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b9074d062d30c2779d8af587924f178a539edde5285d961d2dfbecbac9c4c931"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:463792a249a81b9eb2b63676347f996d3f0082c2666fd0604f4180d2e5445996"},
+    {file = "numpy-1.19.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ea6171d2d8d648dee717457d0f75db49ad8c2f13100680e284d7becf3dc311a6"},
+    {file = "numpy-1.19.3-cp37-cp37m-win32.whl", hash = "sha256:0ee77786eebbfa37f2141fd106b549d37c89207a0d01d8852fde1c82e9bfc0e7"},
+    {file = "numpy-1.19.3-cp37-cp37m-win_amd64.whl", hash = "sha256:271139653e8b7a046d11a78c0d33bafbddd5c443a5b9119618d0652a4eb3a09f"},
+    {file = "numpy-1.19.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e983cbabe10a8989333684c98fdc5dd2f28b236216981e0c26ed359aaa676772"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d78294f1c20f366cde8a75167f822538a7252b6e8b9d6dbfb3bdab34e7c1929e"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:199bebc296bd8a5fc31c16f256ac873dd4d5b4928dfd50e6c4995570fc71a8f3"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:dffed17848e8b968d8d3692604e61881aa6ef1f8074c99e81647ac84f6038535"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:5ea4401ada0d3988c263df85feb33818dc995abc85b8125f6ccb762009e7bc68"},
+    {file = "numpy-1.19.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:604d2e5a31482a3ad2c88206efd43d6fcf666ada1f3188fd779b4917e49b7a98"},
+    {file = "numpy-1.19.3-cp38-cp38-win32.whl", hash = "sha256:a2daea1cba83210c620e359de2861316f49cc7aea8e9a6979d6cb2ddab6dda8c"},
+    {file = "numpy-1.19.3-cp38-cp38-win_amd64.whl", hash = "sha256:dfdc8b53aa9838b9d44ed785431ca47aa3efaa51d0d5dd9c412ab5247151a7c4"},
+    {file = "numpy-1.19.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9f7f56b5e85b08774939622b7d45a5d00ff511466522c44fc0756ac7692c00f2"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8802d23e4895e0c65e418abe67cdf518aa5cbb976d97f42fd591f921d6dffad0"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c4aa79993f5d856765819a3651117520e41ac3f89c3fc1cb6dee11aa562df6da"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:51e8d2ae7c7e985c7bebf218e56f72fa93c900ad0c8a7d9fbbbf362f45710f69"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:50d3513469acf5b2c0406e822d3f314d7ac5788c2b438c24e5dd54d5a81ef522"},
+    {file = "numpy-1.19.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:741d95eb2b505bb7a99fbf4be05fa69f466e240c2b4f2d3ddead4f1b5f82a5a5"},
+    {file = "numpy-1.19.3-cp39-cp39-win32.whl", hash = "sha256:1ea7e859f16e72ab81ef20aae69216cfea870676347510da9244805ff9670170"},
+    {file = "numpy-1.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:83af653bb92d1e248ccf5fdb05ccc934c14b936bcfe9b917dc180d3f00250ac6"},
+    {file = "numpy-1.19.3-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:9a0669787ba8c9d3bb5de5d9429208882fb47764aa79123af25c5edc4f5966b9"},
+    {file = "numpy-1.19.3.zip", hash = "sha256:35bf5316af8dc7c7db1ad45bec603e5fb28671beb98ebd1d65e8059efcfd3b72"},
 ]
 pandas = [
     {file = "pandas-1.1.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:882012763668af54b48f1412bab95c5cc0a7ccce5a2a8221cfc3839a6e3394ef"},
@@ -1113,8 +1123,8 @@ plac = [
     {file = "plac-1.1.3.tar.gz", hash = "sha256:398cb947c60c4c25e275e1f1dadf027e7096858fb260b8ece3b33bcff90d985f"},
 ]
 plotly = [
-    {file = "plotly-4.11.0-py2.py3-none-any.whl", hash = "sha256:584b3dc685c84b652198166969742115b31892de61c86556f909f3f0f9ccd0d3"},
-    {file = "plotly-4.11.0.tar.gz", hash = "sha256:b6ad5c3d2cbf056a782e3c6833a334c45a5453a12dc8a48df971602509e8d3d6"},
+    {file = "plotly-4.12.0-py2.py3-none-any.whl", hash = "sha256:c50babbb4f8ad12e2a4f004df5d80c1dbf10c38e9325b5ffb1146b383687ef52"},
+    {file = "plotly-4.12.0.tar.gz", hash = "sha256:9ec2c9f4cceac7c595ebb77c98cbeb6566a97bef777508584d9bb7d9bcb8854c"},
 ]
 poetry-githooks = [
     {file = "poetry-githooks-1.1.2.tar.gz", hash = "sha256:32d54550ba727603e2e5db32c49d1407f07e72a8f3b40da221c76f09554805f8"},
@@ -1154,8 +1164,8 @@ psycopg2 = [
     {file = "psycopg2-2.8.6.tar.gz", hash = "sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543"},
 ]
 pybind11 = [
-    {file = "pybind11-2.5.0-py2.py3-none-any.whl", hash = "sha256:205d9f9615eac190811cb8c3c2b2f95f6844ddba0fa0a1d45d00793338741601"},
-    {file = "pybind11-2.5.0.tar.gz", hash = "sha256:ea5a4e7a880112915463826f1acbec5892df36dfe102ecb249229ac514fb54ad"},
+    {file = "pybind11-2.6.0-py2.py3-none-any.whl", hash = "sha256:4ddeee54adf844ce44801c32a61e1863dd79283a5ce7afbb96e05fe61fa1fd7d"},
+    {file = "pybind11-2.6.0.tar.gz", hash = "sha256:4107de1fd612bf52953fd64dab7f94f11d2ab3548e1b761cbf8ebc87a2480912"},
 ]
 pygraphviz = [
     {file = "pygraphviz-1.6.zip", hash = "sha256:411ae84a5bc313e3e1523a1cace59159f512336318a510573b47f824edef8860"},
@@ -1173,33 +1183,33 @@ pytz = [
     {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 regex = [
-    {file = "regex-2020.10.15-cp27-cp27m-win32.whl", hash = "sha256:e935a166a5f4c02afe3f7e4ce92ce5a786f75c6caa0c4ce09c922541d74b77e8"},
-    {file = "regex-2020.10.15-cp27-cp27m-win_amd64.whl", hash = "sha256:d81be22d5d462b96a2aa5c512f741255ba182995efb0114e5a946fe254148df1"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:6d4cdb6c20e752426b2e569128488c5046fb1b16b1beadaceea9815c36da0847"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:25991861c6fef1e5fd0a01283cf5658c5e7f7aa644128e85243bc75304e91530"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:6e9f72e0ee49f7d7be395bfa29e9533f0507a882e1e6bf302c0a204c65b742bf"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:578ac6379e65eb8e6a85299b306c966c852712c834dc7eef0ba78d07a828f67b"},
-    {file = "regex-2020.10.15-cp36-cp36m-win32.whl", hash = "sha256:65b6b018b07e9b3b6a05c2c3bb7710ed66132b4df41926c243887c4f1ff303d5"},
-    {file = "regex-2020.10.15-cp36-cp36m-win_amd64.whl", hash = "sha256:2f60ba5c33f00ce9be29a140e6f812e39880df8ba9cb92ad333f0016dbc30306"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5d4a3221f37520bb337b64a0632716e61b26c8ae6aaffceeeb7ad69c009c404b"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:26b85672275d8c7a9d4ff93dbc4954f5146efdb2ecec89ad1de49439984dea14"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:828618f3c3439c5e6ef8621e7c885ca561bbaaba90ddbb6a7dfd9e1ec8341103"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:aef23aed9d4017cc74d37f703d57ce254efb4c8a6a01905f40f539220348abf9"},
-    {file = "regex-2020.10.15-cp37-cp37m-win32.whl", hash = "sha256:6c72adb85adecd4522a488a751e465842cdd2a5606b65464b9168bf029a54272"},
-    {file = "regex-2020.10.15-cp37-cp37m-win_amd64.whl", hash = "sha256:ef3a55b16c6450574734db92e0a3aca283290889934a23f7498eaf417e3af9f0"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8958befc139ac4e3f16d44ec386c490ea2121ed8322f4956f83dd9cad8e9b922"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3dd952f3f8dc01b72c0cf05b3631e05c50ac65ddd2afdf26551638e97502107b"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:608d6c05452c0e6cc49d4d7407b4767963f19c4d2230fa70b7201732eedc84f2"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:02686a2f0b1a4be0facdd0d3ad4dc6c23acaa0f38fb5470d892ae88584ba705c"},
-    {file = "regex-2020.10.15-cp38-cp38-win32.whl", hash = "sha256:137da580d1e6302484be3ef41d72cf5c3ad22a076070051b7449c0e13ab2c482"},
-    {file = "regex-2020.10.15-cp38-cp38-win_amd64.whl", hash = "sha256:20cdd7e1736f4f61a5161aa30d05ac108ab8efc3133df5eb70fe1e6a23ea1ca6"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux1_i686.whl", hash = "sha256:85b733a1ef2b2e7001aff0e204a842f50ad699c061856a214e48cfb16ace7d0c"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:af1f5e997dd1ee71fb6eb4a0fb6921bf7a778f4b62f1f7ef0d7445ecce9155d6"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:b5eeaf4b5ef38fab225429478caf71f44d4a0b44d39a1aa4d4422cda23a9821b"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:aeac7c9397480450016bc4a840eefbfa8ca68afc1e90648aa6efbfe699e5d3bb"},
-    {file = "regex-2020.10.15-cp39-cp39-win32.whl", hash = "sha256:698f8a5a2815e1663d9895830a063098ae2f8f2655ae4fdc5dfa2b1f52b90087"},
-    {file = "regex-2020.10.15-cp39-cp39-win_amd64.whl", hash = "sha256:a51e51eecdac39a50ede4aeed86dbef4776e3b73347d31d6ad0bc9648ba36049"},
-    {file = "regex-2020.10.15.tar.gz", hash = "sha256:d25f5cca0f3af6d425c9496953445bf5b288bb5b71afc2b8308ad194b714c159"},
+    {file = "regex-2020.10.28-cp27-cp27m-win32.whl", hash = "sha256:4b5a9bcb56cc146c3932c648603b24514447eafa6ce9295234767bf92f69b504"},
+    {file = "regex-2020.10.28-cp27-cp27m-win_amd64.whl", hash = "sha256:c13d311a4c4a8d671f5860317eb5f09591fbe8259676b86a85769423b544451e"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c8a2b7ccff330ae4c460aff36626f911f918555660cc28163417cb84ffb25789"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4afa350f162551cf402bfa3cd8302165c8e03e689c897d185f16a167328cc6dd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b88fa3b8a3469f22b4f13d045d9bd3eda797aa4e406fde0a2644bc92bbdd4bdd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f43109822df2d3faac7aad79613f5f02e4eab0fc8ad7932d2e70e2a83bd49c26"},
+    {file = "regex-2020.10.28-cp36-cp36m-win32.whl", hash = "sha256:8092a5a06ad9a7a247f2a76ace121183dc4e1a84c259cf9c2ce3bbb69fac3582"},
+    {file = "regex-2020.10.28-cp36-cp36m-win_amd64.whl", hash = "sha256:49461446b783945597c4076aea3f49aee4b4ce922bd241e4fcf62a3e7c61794c"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8ca9dca965bd86ea3631b975d63b0693566d3cc347e55786d5514988b6f5b84c"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ea37320877d56a7f0a1e6a625d892cf963aa7f570013499f5b8d5ab8402b5625"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:3a5f08039eee9ea195a89e180c5762bfb55258bfb9abb61a20d3abee3b37fd12"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:cb905f3d2e290a8b8f1579d3984f2cfa7c3a29cc7cba608540ceeed18513f520"},
+    {file = "regex-2020.10.28-cp37-cp37m-win32.whl", hash = "sha256:a62162be05edf64f819925ea88d09d18b09bebf20971b363ce0c24e8b4aa14c0"},
+    {file = "regex-2020.10.28-cp37-cp37m-win_amd64.whl", hash = "sha256:03855ee22980c3e4863dc84c42d6d2901133362db5daf4c36b710dd895d78f0a"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_i686.whl", hash = "sha256:625116aca6c4b57c56ea3d70369cacc4d62fead4930f8329d242e4fe7a58ce4b"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dc522e25e57e88b4980d2bdd334825dbf6fa55f28a922fc3bfa60cc09e5ef53"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:119e0355dbdd4cf593b17f2fc5dbd4aec2b8899d0057e4957ba92f941f704bf5"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:cfcf28ed4ce9ced47b9b9670a4f0d3d3c0e4d4779ad4dadb1ad468b097f808aa"},
+    {file = "regex-2020.10.28-cp38-cp38-win32.whl", hash = "sha256:06b52815d4ad38d6524666e0d50fe9173533c9cc145a5779b89733284e6f688f"},
+    {file = "regex-2020.10.28-cp38-cp38-win_amd64.whl", hash = "sha256:c3466a84fce42c2016113101018a9981804097bacbab029c2d5b4fcb224b89de"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c2c6c56ee97485a127555c9595c069201b5161de9d05495fbe2132b5ac104786"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1ec66700a10e3c75f1f92cbde36cca0d3aaee4c73dfa26699495a3a30b09093c"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:11116d424734fe356d8777f89d625f0df783251ada95d6261b4c36ad27a394bb"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f1fce1e4929157b2afeb4bb7069204d4370bab9f4fc03ca1fbec8bd601f8c87d"},
+    {file = "regex-2020.10.28-cp39-cp39-win32.whl", hash = "sha256:832339223b9ce56b7b15168e691ae654d345ac1635eeb367ade9ecfe0e66bee0"},
+    {file = "regex-2020.10.28-cp39-cp39-win_amd64.whl", hash = "sha256:654c1635f2313d0843028487db2191530bca45af61ca85d0b16555c399625b0e"},
+    {file = "regex-2020.10.28.tar.gz", hash = "sha256:dd3e6547ecf842a29cf25123fbf8d2461c53c8d37aa20d87ecee130c89b7079b"},
 ]
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
@@ -1376,8 +1386,8 @@ toml = [
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 tqdm = [
-    {file = "tqdm-4.50.2-py2.py3-none-any.whl", hash = "sha256:43ca183da3367578ebf2f1c2e3111d51ea161ed1dc4e6345b86e27c2a93beff7"},
-    {file = "tqdm-4.50.2.tar.gz", hash = "sha256:69dfa6714dee976e2425a9aab84b622675b7b1742873041e3db8a8e86132a4af"},
+    {file = "tqdm-4.51.0-py2.py3-none-any.whl", hash = "sha256:9ad44aaf0fc3697c06f6e05c7cf025dd66bc7bcb7613c66d85f4464c47ac8fad"},
+    {file = "tqdm-4.51.0.tar.gz", hash = "sha256:ef54779f1c09f346b2b5a8e5c61f96fbcb639929e640e59f8cf810794f406432"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,16 @@ SQLAlchemy = "^1.3.17"
 sqlalchemy_mixins = "^1.2.1"
 textdistance = "^4.2.0"
 psycopg2 = "^2.8.5"
+pandas = "^1.1.2"
+networkx = "^2.5"
 
 # NLP
 nltk = "^3.5"
 spacy = "^2.3.2"
 fasttext = "^0.9.2"
 tables = "^3.6.1"
-pandas = "^1.1.2"
 en_core_web_sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz" } # the English language model for SpaCy
 annoy = "^1.17.0"
-networkx = "^2.5"
 
 [tool.poetry.dev-dependencies]
 eralchemy = "^1.2.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ tables = "^3.6.1"
 pandas = "^1.1.2"
 en_core_web_sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz" } # the English language model for SpaCy
 annoy = "^1.17.0"
+networkx = "^2.5"
 
 [tool.poetry.dev-dependencies]
 eralchemy = "^1.2.10"

--- a/resources/search.sql
+++ b/resources/search.sql
@@ -38,8 +38,14 @@ WITH listing_info
                      JOIN professors p on course_professors.professor_id = p.professor_id
             WHERE course_professors.course_id = courses.course_id
             GROUP BY course_professors.course_id) AS average_professor,
-           (SELECT enrollment FROM evaluation_statistics
-            WHERE evaluation_statistics.course_id = listings.course_id) as enrollment
+           (SELECT enrolled FROM evaluation_statistics
+            WHERE evaluation_statistics.course_id = listings.course_id) as enrolled,
+           (SELECT responses FROM evaluation_statistics
+            WHERE evaluation_statistics.course_id = listings.course_id) as responses,
+           (SELECT declined FROM evaluation_statistics
+            WHERE evaluation_statistics.course_id = listings.course_id) as declined,
+           (SELECT no_response FROM evaluation_statistics
+            WHERE evaluation_statistics.course_id = listings.course_id) as no_response
         FROM listings
         JOIN courses on listings.course_id = courses.course_id
     )
@@ -65,7 +71,10 @@ SELECT listing_id,
        average_professor,
        average_rating,
        average_workload,
-       enrollment,
+       enrolled,
+       responses,
+       declined,
+       no_response,
        to_jsonb(skills) as skills,
        to_jsonb(areas) as areas,
        (setweight(to_tsvector('english', title), 'A') ||

--- a/resources/search.sql
+++ b/resources/search.sql
@@ -8,6 +8,13 @@
 -- See this Hasura blog post for more information on the search function:
 -- https://hasura.io/blog/full-text-search-with-hasura-graphql-api-postgres/
 
+-- encourage index usage
+SET enable_seqscan = OFF;
+SET enable_indexscan = ON;
+SET random_page_cost = 1;
+SET seq_page_cost = 1;
+SET enable_hashjoin = OFF;
+
 DROP FUNCTION IF EXISTS search_listing_info;
 DROP TABLE IF EXISTS computed_listing_info CASCADE;
 


### PR DESCRIPTION
Adds a Pandas-based importer (`ferry/importer_pandas.py`) that performs the same functions as `ferry/importer.py`

Considerations:
- Runtime is ~2 minutes (20% reading inputs, 30% constructing tables in Pandas, 50% pushing to Postgres)
- Produces nearly-identical inputs as current importer
- Note that this resets the entire database upon running, which results in ~1min of downtime as well as the need to run `ferry/computed.py` again.

Also makes a few changes to the main database schema and importer:
- Split `evaluation_statistics` enrollment JSON into separate columns
- Allow professor emails and OCS IDs to be nullable
- Fix season filtering in demand_statistics course matching