### PR TITLE
Add evaluation sentiment to database

### DIFF
--- a/ferry/crawler/parse_ratings.py
+++ b/ferry/crawler/parse_ratings.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import ujson
+from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+from ferry import config
+from ferry.includes.tqdm import tqdm
+
+analyzer = SentimentIntensityAnalyzer()
+
+
+def get_sentiment(comment):
+    sentiment = analyzer.polarity_scores(comment)
+    sentiment["comment"] = comment
+
+    return sentiment
+
+
+def process_narratives(narratives):
+    processed_narratives = []
+
+    for narrative in narratives:
+        processed_narrative = {}
+        processed_narrative["question_text"] = narrative["question_text"]
+        processed_narrative["question_id"] = narrative["question_id"]
+        processed_narrative["comments"] = [
+            get_sentiment(comment) for comment in narrative["comments"]
+        ]
+
+        processed_narratives.append(processed_narrative)
+
+    return processed_narratives
+
+
+print("\n[Importing course evaluations]")
+
+# list available evaluation files
+previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
+new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
+
+previous_eval_files = [x.name for x in previous_eval_files]
+new_eval_files = [x.name for x in new_eval_files]
+
+all_evals = sorted(list(set(previous_eval_files + new_eval_files)))
+
+merged_evaluations = []
+
+for filename in tqdm(all_evals, desc="Loading evaluation JSONs"):
+    # Read the evaluation, giving preference to current over previous.
+    current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
+
+    if current_evals_file.is_file():
+        with open(current_evals_file, "r") as f:
+            evaluation = ujson.load(f)
+    else:
+        with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
+            evaluation = ujson.load(f)
+
+    merged_evaluations.append(evaluation)
+
+
+for evaluation in tqdm(merged_evaluations, desc="Processing evaluations"):
+    evaluation["narratives"] = process_narratives(evaluation["narratives"])
+
+with open(f"{config.DATA_DIR}/merged_evaluations.json", "w") as f:
+    f.write(ujson.dumps(merged_evaluations, indent=4))

--- a/ferry/crawler/parse_ratings.py
+++ b/ferry/crawler/parse_ratings.py
@@ -32,8 +32,6 @@ def process_narratives(narratives):
     return processed_narratives
 
 
-print("\n[Importing course evaluations]")
-
 # list available evaluation files
 previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
 new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -127,7 +127,8 @@ class Course(BaseModel):
         comment='Course times and locations, displayed in the "Meets" row in CourseTable course modals',
     )
     times_summary = Column(
-        String, comment='Course times, displayed in the "Times" column in CourseTable',
+        String,
+        comment='Course times, displayed in the "Times" column in CourseTable',
     )
     times_by_day = Column(
         JSON,
@@ -164,7 +165,8 @@ class Course(BaseModel):
     classnotes = Column(String, comment="Additional class notes")
     final_exam = Column(String, comment="Final exam information")
     fysem = Column(
-        Boolean, comment="True if the course is a first-year seminar. False otherwise.",
+        Boolean,
+        comment="True if the course is a first-year seminar. False otherwise.",
     )
 
     # ----------------
@@ -263,7 +265,9 @@ class Listing(BaseModel):
         nullable=False,
     )
     course_code = Column(
-        String, comment='[computed] subject + number (e.g. "AMST 312")', index=True,
+        String,
+        comment='[computed] subject + number (e.g. "AMST 312")',
+        index=True,
     )
     section = Column(
         String,
@@ -318,7 +322,10 @@ course_flags = Table(
         index=True,
     ),
     Column(
-        "flag_id", ForeignKey("flags_staged.flag_id"), primary_key=True, index=True,
+        "flag_id",
+        ForeignKey("flags_staged.flag_id"),
+        primary_key=True,
+        index=True,
     ),
 )
 
@@ -334,11 +341,20 @@ class DemandStatistics(BaseModel):
         index=True,
         comment="The course to which these demand statistics apply",
     )
-    latest_demand = Column(Integer, comment="Latest demand count",)
-    latest_demand_date = Column(String, comment="Latest demand date",)
+    latest_demand = Column(
+        Integer,
+        comment="Latest demand count",
+    )
+    latest_demand_date = Column(
+        String,
+        comment="Latest demand date",
+    )
     course = relationship("Course", backref="demand_statistics_staged", cascade="all")
 
-    demand = Column(JSON, comment="JSON dict containing demand stats by day",)
+    demand = Column(
+        JSON,
+        comment="JSON dict containing demand stats by day",
+    )
 
 
 class Professor(BaseModel):
@@ -407,7 +423,10 @@ class EvaluationQuestion(BaseModel):
         Boolean,
         comment="True if the question has narrative responses. False if the question has categorica/numerical responses",
     )
-    question_text = Column(String, comment="The question text",)
+    question_text = Column(
+        String,
+        comment="The question text",
+    )
     options = Column(
         JSON,
         comment="JSON array of possible responses (only if the question is not a narrative",
@@ -442,16 +461,30 @@ class EvaluationNarrative(BaseModel):
         nullable=False,
     )
     question = relationship(
-        "EvaluationQuestion", backref="evaluation_narratives_staged", cascade="all",
+        "EvaluationQuestion",
+        backref="evaluation_narratives_staged",
+        cascade="all",
     )
 
-    comment = Column(String, comment="Response to the question",)
+    comment = Column(
+        String,
+        comment="Response to the question",
+    )
 
-    comment_neg = Column(Float, comment="VADER sentiment 'neg' score (negativity)",)
+    comment_neg = Column(
+        Float,
+        comment="VADER sentiment 'neg' score (negativity)",
+    )
 
-    comment_neu = Column(Float, comment="VADER sentiment 'neu' score (neutrality)",)
+    comment_neu = Column(
+        Float,
+        comment="VADER sentiment 'neu' score (neutrality)",
+    )
 
-    comment_pos = Column(Float, comment="VADER sentiment 'pos' score (positivity)",)
+    comment_pos = Column(
+        Float,
+        comment="VADER sentiment 'pos' score (positivity)",
+    )
 
     comment_compound = Column(
         Float,
@@ -483,4 +516,7 @@ class EvaluationRating(BaseModel):
         "EvaluationQuestion", backref="evaluation_ratings_staged", cascade="all"
     )
 
-    rating = Column(JSON, comment="JSON array of the response counts for each option",)
+    rating = Column(
+        JSON,
+        comment="JSON array of the response counts for each option",
+    )

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -127,8 +127,7 @@ class Course(BaseModel):
         comment='Course times and locations, displayed in the "Meets" row in CourseTable course modals',
     )
     times_summary = Column(
-        String,
-        comment='Course times, displayed in the "Times" column in CourseTable',
+        String, comment='Course times, displayed in the "Times" column in CourseTable',
     )
     times_by_day = Column(
         JSON,
@@ -165,8 +164,7 @@ class Course(BaseModel):
     classnotes = Column(String, comment="Additional class notes")
     final_exam = Column(String, comment="Final exam information")
     fysem = Column(
-        Boolean,
-        comment="True if the course is a first-year seminar. False otherwise.",
+        Boolean, comment="True if the course is a first-year seminar. False otherwise.",
     )
 
     # ----------------
@@ -265,9 +263,7 @@ class Listing(BaseModel):
         nullable=False,
     )
     course_code = Column(
-        String,
-        comment='[computed] subject + number (e.g. "AMST 312")',
-        index=True,
+        String, comment='[computed] subject + number (e.g. "AMST 312")', index=True,
     )
     section = Column(
         String,
@@ -322,10 +318,7 @@ course_flags = Table(
         index=True,
     ),
     Column(
-        "flag_id",
-        ForeignKey("flags_staged.flag_id"),
-        primary_key=True,
-        index=True,
+        "flag_id", ForeignKey("flags_staged.flag_id"), primary_key=True, index=True,
     ),
 )
 
@@ -341,20 +334,11 @@ class DemandStatistics(BaseModel):
         index=True,
         comment="The course to which these demand statistics apply",
     )
-    latest_demand = Column(
-        Integer,
-        comment="Latest demand count",
-    )
-    latest_demand_date = Column(
-        String,
-        comment="Latest demand date",
-    )
+    latest_demand = Column(Integer, comment="Latest demand count",)
+    latest_demand_date = Column(String, comment="Latest demand date",)
     course = relationship("Course", backref="demand_statistics_staged", cascade="all")
 
-    demand = Column(
-        JSON,
-        comment="JSON dict containing demand stats by day",
-    )
+    demand = Column(JSON, comment="JSON dict containing demand stats by day",)
 
 
 class Professor(BaseModel):
@@ -423,10 +407,7 @@ class EvaluationQuestion(BaseModel):
         Boolean,
         comment="True if the question has narrative responses. False if the question has categorica/numerical responses",
     )
-    question_text = Column(
-        String,
-        comment="The question text",
-    )
+    question_text = Column(String, comment="The question text",)
     options = Column(
         JSON,
         comment="JSON array of possible responses (only if the question is not a narrative",
@@ -461,14 +442,20 @@ class EvaluationNarrative(BaseModel):
         nullable=False,
     )
     question = relationship(
-        "EvaluationQuestion",
-        backref="evaluation_narratives_staged",
-        cascade="all",
+        "EvaluationQuestion", backref="evaluation_narratives_staged", cascade="all",
     )
 
-    comment = Column(
-        String,
-        comment="Response to the question",
+    comment = Column(String, comment="Response to the question",)
+
+    comment_neg = Column(Float, comment="VADER sentiment 'neg' score (negativity)",)
+
+    comment_neu = Column(Float, comment="VADER sentiment 'neu' score (neutrality)",)
+
+    comment_pos = Column(Float, comment="VADER sentiment 'pos' score (positivity)",)
+
+    comment_compound = Column(
+        Float,
+        comment="VADER sentiment 'compound' score (valence aggregate of neg, neu, pos)",
     )
 
 
@@ -496,7 +483,4 @@ class EvaluationRating(BaseModel):
         "EvaluationQuestion", backref="evaluation_ratings_staged", cascade="all"
     )
 
-    rating = Column(
-        JSON,
-        comment="JSON array of the response counts for each option",
-    )
+    rating = Column(JSON, comment="JSON array of the response counts for each option",)

--- a/ferry/transform.py
+++ b/ferry/transform.py
@@ -126,38 +126,14 @@ if __name__ == "__main__":
 
     print("\n[Importing course evaluations]")
 
-    # list available evaluation files
-    previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
-    new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
-
-    previous_eval_files = [x.name for x in previous_eval_files]
-    new_eval_files = [x.name for x in new_eval_files]
-
-    all_evals = sorted(list(set(previous_eval_files + new_eval_files)))
-
-    merged_evaluations_info = []
-
-    for filename in tqdm(all_evals, desc="Loading evaluation JSONs"):
-        # Read the evaluation, giving preference to current over previous.
-        current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
-
-        if current_evals_file.is_file():
-            with open(current_evals_file, "r") as f:
-                evaluation = ujson.load(f)
-        else:
-            with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
-                evaluation = ujson.load(f)
-
-        merged_evaluations_info.append(evaluation)
-
-    merged_evaluations_info = pd.DataFrame(merged_evaluations_info)
+    merged_evaluations = pd.read_json(f"{config.DATA_DIR}/merged_evaluations.json")
 
     (
         evaluation_narratives,
         evaluation_ratings,
         evaluation_statistics,
         evaluation_questions,
-    ) = import_evaluations(merged_evaluations_info, listings)
+    ) = import_evaluations(merged_evaluations, listings)
 
     # define seasons table for import
     seasons = pd.DataFrame(course_seasons, columns=["season_code"], dtype=int)

--- a/poetry.lock
+++ b/poetry.lock
@@ -148,6 +148,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 
 [[package]]
+name = "dill"
+version = "0.3.3"
+description = "serialize all of python"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*"
+
+[package.extras]
+graph = ["objgraph (>=1.7.2)"]
+
+[[package]]
 name = "diskcache"
 version = "4.1.0"
 description = "Disk Cache -- Disk and file backed persistent cache."
@@ -407,6 +418,17 @@ description = "NumPy is the fundamental package for array computing with Python.
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "pandarallel"
+version = "1.5.1"
+description = "An easy to use library to speed up computation (by parallelizing on multi CPUs) with pandas."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+dill = "*"
 
 [[package]]
 name = "pandas"
@@ -919,6 +941,17 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
+name = "vadersentiment"
+version = "3.3.2"
+description = "VADER Sentiment Analysis. VADER (Valence Aware Dictionary and sEntiment Reasoner) is a lexicon and rule-based sentiment analysis tool that is specifically attuned to sentiments expressed in social media, and works well on texts from other domains."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+requests = "*"
+
+[[package]]
 name = "wasabi"
 version = "0.8.0"
 description = "A lightweight console printing and formatting toolkit"
@@ -945,7 +978,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "91aad153d03293b2e21905defa6efe978f76336ba328c084b7eed8d20991be76"
+content-hash = "f8c31a7b6c57c048eb7801a72ebe64acf12914355f9a0e1da4360fd01fe2260e"
 
 [metadata.files]
 annoy = [
@@ -1031,6 +1064,10 @@ cymem = [
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
     {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+]
+dill = [
+    {file = "dill-0.3.3-py2.py3-none-any.whl", hash = "sha256:78370261be6ea49037ace8c17e0b7dd06d0393af6513cc23f9b222d9367ce389"},
+    {file = "dill-0.3.3.zip", hash = "sha256:efb7f6cb65dba7087c1e111bb5390291ba3616741f96840bfc75792a1a9b5ded"},
 ]
 diskcache = [
     {file = "diskcache-4.1.0-py2.py3-none-any.whl", hash = "sha256:69b253a6ffe95bb4bafb483b97c24fca3c2c6c47b82e92b36486969a7e80d47d"},
@@ -1262,6 +1299,9 @@ numpy = [
     {file = "numpy-1.19.3-cp39-cp39-win_amd64.whl", hash = "sha256:83af653bb92d1e248ccf5fdb05ccc934c14b936bcfe9b917dc180d3f00250ac6"},
     {file = "numpy-1.19.3-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:9a0669787ba8c9d3bb5de5d9429208882fb47764aa79123af25c5edc4f5966b9"},
     {file = "numpy-1.19.3.zip", hash = "sha256:35bf5316af8dc7c7db1ad45bec603e5fb28671beb98ebd1d65e8059efcfd3b72"},
+]
+pandarallel = [
+    {file = "pandarallel-1.5.1.tar.gz", hash = "sha256:28c101e4eeda6a2b49888db413bc16e28bf36feb3e779d58c099ee49cde83849"},
 ]
 pandas = [
     {file = "pandas-1.1.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:882012763668af54b48f1412bab95c5cc0a7ccce5a2a8221cfc3839a6e3394ef"},
@@ -1648,6 +1688,10 @@ unidecode = [
 urllib3 = [
     {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
     {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
+]
+vadersentiment = [
+    {file = "vaderSentiment-3.3.2-py2.py3-none-any.whl", hash = "sha256:3bf1d243b98b1afad575b9f22bc2cb1e212b94ff89ca74f8a23a588d024ea311"},
+    {file = "vaderSentiment-3.3.2.tar.gz", hash = "sha256:5d7c06e027fc8b99238edb0d53d970cf97066ef97654009890b83703849632f9"},
 ]
 wasabi = [
     {file = "wasabi-0.8.0-py3-none-any.whl", hash = "sha256:98bc9c492c6aa8628303a02961a5cfa7b0c7fa6d2b397abdeb0adc4b39397c49"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ fasttext = "^0.9.2"
 tables = "^3.6.1"
 en_core_web_sm = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz" } # the English language model for SpaCy
 annoy = "^1.17.0"
+vaderSentiment = "^3.3.2"
+pandarallel = "^1.5.1"
 
 [tool.poetry.dev-dependencies]
 eralchemy = "^1.2.10"

--- a/refresh_courses.sh
+++ b/refresh_courses.sh
@@ -27,6 +27,9 @@ poetry run python ./ferry/crawler/fetch_classes.py -s LATEST_3
 announce "Parsing all classes"
 poetry run python ./ferry/crawler/parse_classes.py
 
+announce "Parsing all evaluations"
+poetry run python ./ferry/crawler/parse_ratings.py
+
 announce "Fetching and parsing demand statistics for latest year"
 poetry run python ./ferry/crawler/fetch_demand.py -s LATEST_3
 


### PR DESCRIPTION
Creates four new columns in `evaluation_narratives` with sentiment scores per comment (row):
- `comment_neg`: the negativity score returned by VADER
- `comment_neu`: the neutrality score returned by VADER
- `comment_pos`: the positivity score returned by VADER
- `comment_compound`: the compound polarity score returned by VADER

Also modifies the evaluations importing pipeline to add a `/ferry/crawler/parse_ratings.py` script that compiles all evaluations and computes the sentiment scores (takes about 5 minutes to run). The output of this script (`/data/merged_evaluations.json`) is now input to transform.py.