### PR TITLE
Reduce memory

### DIFF
--- a/ferry/crawler/parse_ratings.py
+++ b/ferry/crawler/parse_ratings.py
@@ -1,49 +1,184 @@
+import csv
 from pathlib import Path
 
+import pandas as pd
 import ujson
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
 
 from ferry import config
 from ferry.includes.tqdm import tqdm
 
+"""
+=================================================================
+This script loads the ratings JSON files from fetch_ratings.py
+and compiles them into tables for questions, ratings, statistics,
+and narratives for input into transform.py. It also computes
+sentiment intensity estimates over the narratives with VADER.
+=================================================================
+"""
+
+# initialize sentiment intensity analyzer
 analyzer = SentimentIntensityAnalyzer()
 
+# ------------------
+# CSV output headers
+# ------------------
 
-def get_sentiment(comment):
-    sentiment = analyzer.polarity_scores(comment)
-    sentiment["comment"] = comment
+questions_headers = [
+    "question_code",
+    "is_narrative",
+    "question_text",
+    "options",
+]
+ratings_headers = ["season", "crn", "question_code", "rating"]
+statistics_headers = [
+    "season",
+    "crn",
+    "enrolled",
+    "responses",
+    "declined",
+    "no_response",
+    "extras",
+]
+narratives_headers = [
+    "season",
+    "crn",
+    "question_code",
+    "comment",
+    "comment_neg",
+    "comment_neu",
+    "comment_pos",
+    "comment_compound",
+]
 
-    return sentiment
+# ----------------
+# CSV output paths
+# ----------------
+
+questions_path = config.DATA_DIR / "parsed_evaluations/evaluation_questions.csv"
+ratings_path = config.DATA_DIR / "parsed_evaluations/evaluation_ratings.csv"
+statistics_path = config.DATA_DIR / "parsed_evaluations/evaluation_statistics.csv"
+narratives_path = config.DATA_DIR / "parsed_evaluations/evaluation_narratives.csv"
+
+# ------------------
+# CSV output writers
+# ------------------
+
+questions_file = open(questions_path, "w")
+questions_writer = csv.DictWriter(questions_file, questions_headers)
+questions_writer.writeheader()
+
+narratives_file = open(narratives_path, "w")
+narratives_writer = csv.DictWriter(narratives_file, narratives_headers)
+narratives_writer.writeheader()
+
+ratings_file = open(ratings_path, "w")
+ratings_writer = csv.DictWriter(ratings_file, ratings_headers)
+ratings_writer.writeheader()
+
+statistics_file = open(statistics_path, "w")
+statistics_writer = csv.DictWriter(statistics_file, statistics_headers)
+statistics_writer.writeheader()
 
 
-def process_narratives(narratives):
-    processed_narratives = []
+def process_narratives(evaluation):
 
-    for narrative in narratives:
-        processed_narrative = {}
-        processed_narrative["question_text"] = narrative["question_text"]
-        processed_narrative["question_id"] = narrative["question_id"]
-        processed_narrative["comments"] = [
-            get_sentiment(comment) for comment in narrative["comments"]
-        ]
+    for narrative_group in evaluation["narratives"]:
 
-        processed_narratives.append(processed_narrative)
+        for raw_narrative in narrative_group["comments"]:
 
-    return processed_narratives
+            narrative = {}
+            narrative["season"] = evaluation["season"]
+            narrative["crn"] = evaluation["crn_code"]
+            narrative["question_code"] = narrative_group["question_id"]
+            narrative["comment"] = raw_narrative
 
+            sentiment = analyzer.polarity_scores(raw_narrative)
+
+            narrative["comment_neg"] = sentiment["neg"]
+            narrative["comment_neu"] = sentiment["neu"]
+            narrative["comment_pos"] = sentiment["pos"]
+            narrative["comment_compound"] = sentiment["compound"]
+
+            narratives_writer.writerow(narrative)
+
+
+def process_ratings(evaluation):
+
+    for raw_rating in evaluation["ratings"]:
+        rating = {}
+
+        rating["season"] = evaluation["season"]
+        rating["crn"] = evaluation["crn_code"]
+        rating["question_code"] = raw_rating["question_id"]
+        rating["rating"] = raw_rating["data"]
+
+        ratings_writer.writerow(rating)
+
+
+def process_statistics(evaluation):
+
+    statistics = {}
+    statistics["season"] = evaluation["season"]
+    statistics["crn"] = evaluation["crn_code"]
+    statistics["enrolled"] = evaluation["enrollment"]["enrolled"]
+    statistics["responses"] = evaluation["enrollment"]["responses"]
+    statistics["declined"] = evaluation["enrollment"]["declined"]
+    statistics["no_response"] = evaluation["enrollment"]["no response"]
+    statistics["extras"] = evaluation["extras"]
+
+    statistics_writer.writerow(statistics)
+
+
+def process_questions(evaluation):
+    questions = []
+    for rating in evaluation["ratings"]:
+        question = {}
+        question["question_code"] = rating["question_id"]
+        question["question_text"] = rating["question_text"]
+        question["is_narrative"] = False
+        question["options"] = rating["options"]
+
+        questions_writer.writerow(question)
+
+    for narrative in evaluation["narratives"]:
+
+        question = {}
+        question["question_code"] = narrative["question_id"]
+        question["question_text"] = narrative["question_text"]
+        question["is_narrative"] = True
+        question["options"] = None
+
+        questions_writer.writerow(question)
+
+
+def process_evaluation(evaluation):
+
+    process_narratives(evaluation)
+    process_ratings(evaluation)
+    process_statistics(evaluation)
+    process_questions(evaluation)
+
+    return
+
+
+# ----------------------------
+# Load and process evaluations
+# ----------------------------
 
 # list available evaluation files
 previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
 new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
 
+# extract file names (<season> + <crn> format) for merging
 previous_eval_files = [x.name for x in previous_eval_files]
 new_eval_files = [x.name for x in new_eval_files]
 
-all_evals = sorted(list(set(previous_eval_files + new_eval_files)))
+all_eval_files = sorted(list(set(previous_eval_files + new_eval_files)))
 
 merged_evaluations = []
 
-for filename in tqdm(all_evals, desc="Loading evaluation JSONs"):
+for filename in tqdm(all_eval_files, desc="Processing evaluations"):
     # Read the evaluation, giving preference to current over previous.
     current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
 
@@ -54,11 +189,10 @@ for filename in tqdm(all_evals, desc="Loading evaluation JSONs"):
         with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
             evaluation = ujson.load(f)
 
-    merged_evaluations.append(evaluation)
+    process_evaluation(evaluation)
 
-
-for evaluation in tqdm(merged_evaluations, desc="Processing evaluations"):
-    evaluation["narratives"] = process_narratives(evaluation["narratives"])
-
-with open(f"{config.DATA_DIR}/merged_evaluations.json", "w") as f:
-    f.write(ujson.dumps(merged_evaluations, indent=4))
+# close CSV files
+questions_file.close()
+narratives_file.close()
+ratings_file.close()
+statistics_file.close()

--- a/ferry/crawler/parse_ratings.py
+++ b/ferry/crawler/parse_ratings.py
@@ -167,37 +167,39 @@ def process_evaluation(evaluation):
     return
 
 
-# ----------------------------
-# Load and process evaluations
-# ----------------------------
+if __name__ == "__main__":
 
-# list available evaluation files
-previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
-new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
+    # ----------------------------
+    # Load and process evaluations
+    # ----------------------------
 
-# extract file names (<season> + <crn> format) for merging
-previous_eval_files = [x.name for x in previous_eval_files]
-new_eval_files = [x.name for x in new_eval_files]
+    # list available evaluation files
+    previous_eval_files = Path(config.DATA_DIR / "previous_evals").glob("*.json")
+    new_eval_files = Path(config.DATA_DIR / "course_evals").glob("*.json")
 
-all_eval_files = sorted(list(set(previous_eval_files + new_eval_files)))
+    # extract file names (<season> + <crn> format) for merging
+    previous_eval_files = [x.name for x in previous_eval_files]
+    new_eval_files = [x.name for x in new_eval_files]
 
-merged_evaluations = []
+    all_eval_files = sorted(list(set(previous_eval_files + new_eval_files)))
 
-for filename in tqdm(all_eval_files, desc="Processing evaluations"):
-    # Read the evaluation, giving preference to current over previous.
-    current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
+    merged_evaluations = []
 
-    if current_evals_file.is_file():
-        with open(current_evals_file, "r") as f:
-            evaluation = ujson.load(f)
-    else:
-        with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
-            evaluation = ujson.load(f)
+    for filename in tqdm(all_eval_files, desc="Processing evaluations"):
+        # Read the evaluation, giving preference to current over previous.
+        current_evals_file = Path(f"{config.DATA_DIR}/course_evals/{filename}")
 
-    process_evaluation(evaluation)
+        if current_evals_file.is_file():
+            with open(current_evals_file, "r") as f:
+                evaluation = ujson.load(f)
+        else:
+            with open(f"{config.DATA_DIR}/previous_evals/{filename}", "r") as f:
+                evaluation = ujson.load(f)
 
-# close CSV files
-questions_file.close()
-narratives_file.close()
-ratings_file.close()
-statistics_file.close()
+        process_evaluation(evaluation)
+
+    # close CSV files
+    questions_file.close()
+    narratives_file.close()
+    ratings_file.close()
+    statistics_file.close()

--- a/ferry/crawler/parse_ratings.py
+++ b/ferry/crawler/parse_ratings.py
@@ -25,6 +25,8 @@ analyzer = SentimentIntensityAnalyzer()
 # ------------------
 
 questions_headers = [
+    "season",
+    "crn",
     "question_code",
     "is_narrative",
     "question_text",
@@ -131,9 +133,10 @@ def process_statistics(evaluation):
 
 
 def process_questions(evaluation):
-    questions = []
     for rating in evaluation["ratings"]:
         question = {}
+        question["season"] = evaluation["season"]
+        question["crn"] = evaluation["crn_code"]
         question["question_code"] = rating["question_id"]
         question["question_text"] = rating["question_text"]
         question["is_narrative"] = False
@@ -144,6 +147,8 @@ def process_questions(evaluation):
     for narrative in evaluation["narratives"]:
 
         question = {}
+        question["season"] = evaluation["season"]
+        question["crn"] = evaluation["crn_code"]
         question["question_code"] = narrative["question_id"]
         question["question_text"] = narrative["question_text"]
         question["is_narrative"] = True

--- a/ferry/crawler/parse_ratings.py
+++ b/ferry/crawler/parse_ratings.py
@@ -113,7 +113,7 @@ def process_ratings(evaluation):
         rating["season"] = evaluation["season"]
         rating["crn"] = evaluation["crn_code"]
         rating["question_code"] = raw_rating["question_id"]
-        rating["rating"] = raw_rating["data"]
+        rating["rating"] = ujson.dumps(raw_rating["data"])
 
         ratings_writer.writerow(rating)
 
@@ -140,7 +140,7 @@ def process_questions(evaluation):
         question["question_code"] = rating["question_id"]
         question["question_text"] = rating["question_text"]
         question["is_narrative"] = False
-        question["options"] = rating["options"]
+        question["options"] = ujson.dumps(rating["options"])
 
         questions_writer.writerow(question)
 

--- a/ferry/includes/computed.py
+++ b/ferry/includes/computed.py
@@ -14,6 +14,7 @@ with open(f"{config.RESOURCE_DIR}/question_tags.csv") as f:
         QUESTION_TAGS[question_code] = tag
 
 
+@profile
 def questions_computed(evaluation_questions):
     """
     Populate computed question fields:
@@ -55,6 +56,7 @@ def questions_computed(evaluation_questions):
     return evaluation_questions
 
 
+@profile
 def evaluation_statistics_computed(
     evaluation_statistics, evaluation_ratings, evaluation_questions
 ):
@@ -137,6 +139,7 @@ def evaluation_statistics_computed(
     return evaluation_statistics
 
 
+@profile
 def courses_computed(courses, listings, evaluation_statistics, course_professors):
     """
     Populate computed course fields:
@@ -306,6 +309,7 @@ def courses_computed(courses, listings, evaluation_statistics, course_professors
     return courses
 
 
+@profile
 def professors_computed(professors, course_professors, evaluation_statistics):
 
     """

--- a/ferry/includes/computed.py
+++ b/ferry/includes/computed.py
@@ -14,7 +14,6 @@ with open(f"{config.RESOURCE_DIR}/question_tags.csv") as f:
         QUESTION_TAGS[question_code] = tag
 
 
-@profile
 def questions_computed(evaluation_questions):
     """
     Populate computed question fields:
@@ -56,7 +55,6 @@ def questions_computed(evaluation_questions):
     return evaluation_questions
 
 
-@profile
 def evaluation_statistics_computed(
     evaluation_statistics, evaluation_ratings, evaluation_questions
 ):
@@ -139,7 +137,6 @@ def evaluation_statistics_computed(
     return evaluation_statistics
 
 
-@profile
 def courses_computed(courses, listings, evaluation_statistics, course_professors):
     """
     Populate computed course fields:
@@ -309,7 +306,6 @@ def courses_computed(courses, listings, evaluation_statistics, course_professors
     return courses
 
 
-@profile
 def professors_computed(professors, course_professors, evaluation_statistics):
 
     """

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -535,6 +535,10 @@ def import_evaluations(
     evaluation_ratings.dropna(subset=["course_id"], axis=0, inplace=True)
     evaluation_statistics.dropna(subset=["course_id"], axis=0, inplace=True)
 
+    evaluation_narratives["course_id"] = evaluation_narratives["course_id"].astype(int)
+    evaluation_ratings["course_id"] = evaluation_ratings["course_id"].astype(int)
+    evaluation_statistics["course_id"] = evaluation_statistics["course_id"].astype(int)
+
     evaluation_statistics.drop_duplicates(
         subset=["course_id"], inplace=True, keep="first"
     )

--- a/ferry/includes/importer.py
+++ b/ferry/includes/importer.py
@@ -528,6 +528,10 @@ def import_evaluations(evaluations, listings):
     # keep track of unique questions
     evaluation_questions = []
 
+    # -----------------------------------------
+    # Evaluation narratives (written responses)
+    # -----------------------------------------
+
     # extract evaluation narratives
     evaluation_narratives = evaluations.loc[
         :, ["course_id", "narratives", "season"]
@@ -538,9 +542,6 @@ def import_evaluations(evaluations, listings):
 
     # subset and explode
     evaluation_narratives = evaluation_narratives.explode("narratives")
-
-    # narratives = pd.DataFrame(evaluation_narratives["narratives"].values.tolist(),index=evaluation_narratives.index)
-    # narratives = narratives.rename({"question_id":"question_code","question_text":"question_text","comments":"comments"},axis=1)
 
     # extract attributes into separate columns
     (
@@ -584,6 +585,7 @@ def import_evaluations(evaluations, listings):
             lambda x: [x["comment"], x["neg"], x["neu"], x["pos"], x["compound"]],
         )
     )
+
     # drop old comment column
     evaluation_narratives.drop(["comments"], axis=1, inplace=True)
 
@@ -601,6 +603,10 @@ def import_evaluations(evaluations, listings):
     evaluation_narratives = evaluation_narratives.reset_index(drop=True)
     # id column for database primary key
     evaluation_narratives["id"] = range(len(evaluation_narratives))
+
+    # ------------------------------------------
+    # Evaluation ratings (categorical responses)
+    # ------------------------------------------
 
     # subset and explode
     evaluation_ratings = evaluations.loc[:, ["course_id", "ratings", "season"]].copy(
@@ -643,6 +649,10 @@ def import_evaluations(evaluations, listings):
         ].copy(deep=True)
     )
 
+    # ----------------------------------
+    # Evaluation statistics (enrollment)
+    # ----------------------------------
+
     # extract evaluation statistics
     evaluation_statistics = evaluations.loc[
         :, ["course_id", "enrollment", "extras"]
@@ -663,6 +673,10 @@ def import_evaluations(evaluations, listings):
     evaluation_statistics["enrollment"] = np.nan
     # convert to JSON string for postgres
     evaluation_statistics["extras"] = evaluation_statistics["extras"].apply(ujson.dumps)
+
+    # --------------------
+    # Evaluation questions
+    # --------------------
 
     evaluation_questions = pd.concat(evaluation_questions, axis=0, sort=True)
     evaluation_questions = evaluation_questions.reset_index(drop=True)
@@ -726,6 +740,10 @@ def import_evaluations(evaluations, listings):
     evaluation_questions["options"] = evaluation_questions["options"].replace(
         "NaN", "[]"
     )
+
+    # -------------------
+    # Clean up and subset
+    # -------------------
 
     # explicitly specify missing columns to be filled in later
     evaluation_statistics[["avg_rating", "avg_workload"]] = np.nan

--- a/ferry/transform.py
+++ b/ferry/transform.py
@@ -127,14 +127,37 @@ if __name__ == "__main__":
 
     print("\n[Importing course evaluations]")
 
-    merged_evaluations = pd.read_json(f"{config.DATA_DIR}/merged_evaluations.json")
+    evaluation_narratives = pd.read_csv(
+        config.DATA_DIR / "parsed_evaluations/evaluation_narratives.csv",
+        dtype={"season": int, "crn": int},
+    )
+    evaluation_ratings = pd.read_csv(
+        config.DATA_DIR / "parsed_evaluations/evaluation_ratings.csv",
+        dtype={"season": int, "crn": int},
+    )
+    evaluation_statistics = pd.read_csv(
+        config.DATA_DIR / "parsed_evaluations/evaluation_statistics.csv",
+        dtype={"season": int, "crn": int},
+    )
+    evaluation_questions = pd.read_csv(
+        config.DATA_DIR / "parsed_evaluations/evaluation_questions.csv",
+        dtype={"season": int, "crn": int},
+    )
+
+    evaluation_ratings["rating"] = evaluation_ratings["rating"].apply(ujson.loads)
 
     (
         evaluation_narratives,
         evaluation_ratings,
         evaluation_statistics,
         evaluation_questions,
-    ) = import_evaluations(merged_evaluations, listings)
+    ) = import_evaluations(
+        evaluation_narratives,
+        evaluation_ratings,
+        evaluation_statistics,
+        evaluation_questions,
+        listings,
+    )
 
     # define seasons table for import
     seasons = pd.DataFrame(course_seasons, columns=["season_code"], dtype=int)
@@ -174,18 +197,21 @@ if __name__ == "__main__":
 
     csv_dir = config.DATA_DIR / "importer_dumps"
 
-    seasons.to_csv(csv_dir / "seasons.csv")
+    def export_csv(table, table_name, csv_kwargs={}):
+        table.to_csv(csv_dir / f"{table_name}.csv", **csv_kwargs)
 
-    courses.to_csv(csv_dir / "courses.csv")
-    listings.to_csv(csv_dir / "listings.csv")
-    professors.to_csv(csv_dir / "professors.csv")
-    course_professors.to_csv(csv_dir / "course_professors.csv")
-    flags.to_csv(csv_dir / "flags.csv")
-    course_flags.to_csv(csv_dir / "course_flags.csv")
+    export_csv(seasons, "seasons")
 
-    demand_statistics.to_csv(csv_dir / "demand_statistics.csv")
+    export_csv(courses, "courses")
+    export_csv(listings, "listings")
+    export_csv(professors, "professors")
+    export_csv(course_professors, "course_professors")
+    export_csv(flags, "flags")
+    export_csv(course_flags, "course_flags")
 
-    evaluation_questions.to_csv(csv_dir / "evaluation_questions.csv")
-    evaluation_narratives.to_csv(csv_dir / "evaluation_narratives.csv")
-    evaluation_ratings.to_csv(csv_dir / "evaluation_ratings.csv")
-    evaluation_statistics.to_csv(csv_dir / "evaluation_statistics.csv")
+    export_csv(demand_statistics, "demand_statistics")
+
+    export_csv(evaluation_questions, "evaluation_questions")
+    export_csv(evaluation_narratives, "evaluation_narratives")
+    export_csv(evaluation_ratings, "evaluation_ratings")
+    export_csv(evaluation_statistics, "evaluation_statistics")

--- a/ferry/transform.py
+++ b/ferry/transform.py
@@ -92,6 +92,7 @@ if __name__ == "__main__":
         course_flags,
         flags,
     ) = import_courses(merged_course_info, course_seasons)
+    del merged_course_info
 
     # ------------------------
     # Import demand statistics

--- a/poetry.lock
+++ b/poetry.lock
@@ -132,6 +132,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "cycler"
+version = "0.10.0"
+description = "Composable style cycles"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 name = "cymem"
 version = "2.0.3"
 description = "Manage calls to calloc/free through Cython"
@@ -289,6 +300,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "kiwisolver"
+version = "1.3.1"
+description = "A fast implementation of the Cassowary constraint solver"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "lazy-object-proxy"
 version = "1.4.3"
 description = "A fast and thorough lazy object proxy."
@@ -319,12 +338,40 @@ htmlsoup = ["beautifulsoup4"]
 source = ["Cython (>=0.29.7)"]
 
 [[package]]
+name = "matplotlib"
+version = "3.3.2"
+description = "Python plotting package"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+certifi = ">=2020.06.20"
+cycler = ">=0.10"
+kiwisolver = ">=1.0.1"
+numpy = ">=1.15"
+pillow = ">=6.2.0"
+pyparsing = ">=2.0.3,<2.0.4 || >2.0.4,<2.1.2 || >2.1.2,<2.1.6 || >2.1.6"
+python-dateutil = ">=2.1"
+
+[[package]]
 name = "mccabe"
 version = "0.6.1"
 description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "memory-profiler"
+version = "0.58.0"
+description = "A module for monitoring memory usage of a python program"
+category = "dev"
+optional = false
+python-versions = ">=3.4"
+
+[package.dependencies]
+psutil = "*"
 
 [[package]]
 name = "murmurhash"
@@ -485,6 +532,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pillow"
+version = "8.0.1"
+description = "Python Imaging Library (Fork)"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "plac"
 version = "1.1.3"
 description = "The smartest command line arguments parser in the world"
@@ -538,6 +593,17 @@ python-versions = ">=3.6.1"
 
 [package.dependencies]
 wcwidth = "*"
+
+[[package]]
+name = "psutil"
+version = "5.7.3"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 
 [[package]]
 name = "psycopg2"
@@ -596,6 +662,14 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
+
+[[package]]
+name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "python-dateutil"
@@ -978,7 +1052,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f8c31a7b6c57c048eb7801a72ebe64acf12914355f9a0e1da4360fd01fe2260e"
+content-hash = "5fb0efc24ac2eb881aeee41cfe1efbaf71dc6d4afdbef447eb8ec74101966559"
 
 [metadata.files]
 annoy = [
@@ -1047,6 +1121,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+cycler = [
+    {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},
+    {file = "cycler-0.10.0.tar.gz", hash = "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"},
+]
 cymem = [
     {file = "cymem-2.0.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f4f19af4bca81f11922508a9dcf30ce1d2aee4972af9f81ce8e5331a6f46f5e1"},
     {file = "cymem-2.0.3-cp35-cp35m-win_amd64.whl", hash = "sha256:cd21ec48ee70878d46c486e2f7ae94b32bfc6b37c4d27876c5a5a00c4eb75c3c"},
@@ -1104,6 +1182,40 @@ jedi = [
 joblib = [
     {file = "joblib-0.17.0-py3-none-any.whl", hash = "sha256:698c311779f347cf6b7e6b8a39bb682277b8ee4aba8cf9507bc0cf4cd4737b72"},
     {file = "joblib-0.17.0.tar.gz", hash = "sha256:9e284edd6be6b71883a63c9b7f124738a3c16195513ad940eae7e3438de885d5"},
+]
+kiwisolver = [
+    {file = "kiwisolver-1.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-win32.whl", hash = "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9"},
+    {file = "kiwisolver-1.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-win32.whl", hash = "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc"},
+    {file = "kiwisolver-1.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-win32.whl", hash = "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-win32.whl", hash = "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3"},
+    {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6"},
+    {file = "kiwisolver-1.3.1.tar.gz", hash = "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
@@ -1184,9 +1296,32 @@ lxml = [
     {file = "lxml-4.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:7ecaef52fd9b9535ae5f01a1dd2651f6608e4ec9dc136fc4dfe7ebe3c3ddb230"},
     {file = "lxml-4.6.1.tar.gz", hash = "sha256:c152b2e93b639d1f36ec5a8ca24cde4a8eefb2b6b83668fcd8e83a67badcb367"},
 ]
+matplotlib = [
+    {file = "matplotlib-3.3.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:27f9de4784ae6fb97679556c5542cf36c0751dccb4d6407f7c62517fa2078868"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:06866c138d81a593b535d037b2727bec9b0818cadfe6a81f6ec5715b8dd38a89"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5ccecb5f78b51b885f0028b646786889f49c54883e554fca41a2a05998063f23"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-win32.whl", hash = "sha256:69cf76d673682140f46c6cb5e073332c1f1b2853c748dc1cb04f7d00023567f7"},
+    {file = "matplotlib-3.3.2-cp36-cp36m-win_amd64.whl", hash = "sha256:371518c769d84af8ec9b7dcb871ac44f7a67ef126dd3a15c88c25458e6b6d205"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:793e061054662aa27acaff9201cdd510a698541c6e8659eeceb31d66c16facc6"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:16b241c3d17be786966495229714de37de04472da472277869b8d5b456a8df00"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3fb0409754b26f48045bacd6818e44e38ca9338089f8ba689e2f9344ff2847c7"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:548cfe81476dbac44db96e9c0b074b6fb333b4d1f12b1ae68dbed47e45166384"},
+    {file = "matplotlib-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f0268613073df055bcc6a490de733012f2cf4fe191c1adb74e41cec8add1a165"},
+    {file = "matplotlib-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:57be9e21073fc367237b03ecac0d9e4b8ddbe38e86ec4a316857d8d93ac9286c"},
+    {file = "matplotlib-3.3.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:be2f0ec62e0939a9dcfd3638c140c5a74fc929ee3fd1f31408ab8633db6e1523"},
+    {file = "matplotlib-3.3.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c5d0c2ae3e3ed4e9f46b7c03b40d443601012ffe8eb8dfbb2bd6b2d00509f797"},
+    {file = "matplotlib-3.3.2-cp38-cp38-win32.whl", hash = "sha256:a522de31e07ed7d6f954cda3fbd5ca4b8edbfc592a821a7b00291be6f843292e"},
+    {file = "matplotlib-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:8bc1d3284dee001f41ec98f59675f4d723683e1cc082830b440b5f081d8e0ade"},
+    {file = "matplotlib-3.3.2-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:799c421bc245a0749c1515b6dea6dc02db0a8c1f42446a0f03b3b82a60a900dc"},
+    {file = "matplotlib-3.3.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:2f5eefc17dc2a71318d5a3496313be5c351c0731e8c4c6182c9ac3782cfc4076"},
+    {file = "matplotlib-3.3.2.tar.gz", hash = "sha256:3d2edbf59367f03cd9daf42939ca06383a7d7803e3993eb5ff1bee8e8a3fbb6b"},
+]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+memory-profiler = [
+    {file = "memory_profiler-0.58.0.tar.gz", hash = "sha256:01385ac0fec944fcf7969814ec4406c6d8a9c66c079d09276723c5a7680f44e5"},
 ]
 murmurhash = [
     {file = "murmurhash-1.0.2-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:717196a04cdc80cc3103a3da17b2415a8a5e1d0d578b7079259386bf153b3258"},
@@ -1340,6 +1475,36 @@ pickleshare = [
     {file = "pickleshare-0.7.5-py2.py3-none-any.whl", hash = "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"},
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
+pillow = [
+    {file = "Pillow-8.0.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:b63d4ff734263ae4ce6593798bcfee6dbfb00523c82753a3a03cbc05555a9cc3"},
+    {file = "Pillow-8.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5f9403af9c790cc18411ea398a6950ee2def2a830ad0cfe6dc9122e6d528b302"},
+    {file = "Pillow-8.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6b4a8fd632b4ebee28282a9fef4c341835a1aa8671e2770b6f89adc8e8c2703c"},
+    {file = "Pillow-8.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:cc3ea6b23954da84dbee8025c616040d9aa5eaf34ea6895a0a762ee9d3e12e11"},
+    {file = "Pillow-8.0.1-cp36-cp36m-win32.whl", hash = "sha256:d8a96747df78cda35980905bf26e72960cba6d355ace4780d4bdde3b217cdf1e"},
+    {file = "Pillow-8.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:7ba0ba61252ab23052e642abdb17fd08fdcfdbbf3b74c969a30c58ac1ade7cd3"},
+    {file = "Pillow-8.0.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:795e91a60f291e75de2e20e6bdd67770f793c8605b553cb6e4387ce0cb302e09"},
+    {file = "Pillow-8.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0a2e8d03787ec7ad71dc18aec9367c946ef8ef50e1e78c71f743bc3a770f9fae"},
+    {file = "Pillow-8.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:006de60d7580d81f4a1a7e9f0173dc90a932e3905cc4d47ea909bc946302311a"},
+    {file = "Pillow-8.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:bd7bf289e05470b1bc74889d1466d9ad4a56d201f24397557b6f65c24a6844b8"},
+    {file = "Pillow-8.0.1-cp37-cp37m-win32.whl", hash = "sha256:95edb1ed513e68bddc2aee3de66ceaf743590bf16c023fb9977adc4be15bd3f0"},
+    {file = "Pillow-8.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:e38d58d9138ef972fceb7aeec4be02e3f01d383723965bfcef14d174c8ccd039"},
+    {file = "Pillow-8.0.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d3d07c86d4efa1facdf32aa878bd508c0dc4f87c48125cc16b937baa4e5b5e11"},
+    {file = "Pillow-8.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:fbd922f702582cb0d71ef94442bfca57624352622d75e3be7a1e7e9360b07e72"},
+    {file = "Pillow-8.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:92c882b70a40c79de9f5294dc99390671e07fc0b0113d472cbea3fde15db1792"},
+    {file = "Pillow-8.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7c9401e68730d6c4245b8e361d3d13e1035cbc94db86b49dc7da8bec235d0015"},
+    {file = "Pillow-8.0.1-cp38-cp38-win32.whl", hash = "sha256:6c1aca8231625115104a06e4389fcd9ec88f0c9befbabd80dc206c35561be271"},
+    {file = "Pillow-8.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:cc9ec588c6ef3a1325fa032ec14d97b7309db493782ea8c304666fb10c3bd9a7"},
+    {file = "Pillow-8.0.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:eb472586374dc66b31e36e14720747595c2b265ae962987261f044e5cce644b5"},
+    {file = "Pillow-8.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:0eeeae397e5a79dc088d8297a4c2c6f901f8fb30db47795113a4a605d0f1e5ce"},
+    {file = "Pillow-8.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:81f812d8f5e8a09b246515fac141e9d10113229bc33ea073fec11403b016bcf3"},
+    {file = "Pillow-8.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:895d54c0ddc78a478c80f9c438579ac15f3e27bf442c2a9aa74d41d0e4d12544"},
+    {file = "Pillow-8.0.1-cp39-cp39-win32.whl", hash = "sha256:2fb113757a369a6cdb189f8df3226e995acfed0a8919a72416626af1a0a71140"},
+    {file = "Pillow-8.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:59e903ca800c8cfd1ebe482349ec7c35687b95e98cefae213e271c8c7fffa021"},
+    {file = "Pillow-8.0.1-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:5abd653a23c35d980b332bc0431d39663b1709d64142e3652890df4c9b6970f6"},
+    {file = "Pillow-8.0.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:4b0ef2470c4979e345e4e0cc1bbac65fda11d0d7b789dbac035e4c6ce3f98adb"},
+    {file = "Pillow-8.0.1-pp37-pypy37_pp73-win32.whl", hash = "sha256:8de332053707c80963b589b22f8e0229f1be1f3ca862a932c1bcd48dafb18dd8"},
+    {file = "Pillow-8.0.1.tar.gz", hash = "sha256:11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e"},
+]
 plac = [
     {file = "plac-1.1.3-py2.py3-none-any.whl", hash = "sha256:487e553017d419f35add346c4c09707e52fa53f7e7181ce1098ca27620e9ceee"},
     {file = "plac-1.1.3.tar.gz", hash = "sha256:398cb947c60c4c25e275e1f1dadf027e7096858fb260b8ece3b33bcff90d985f"},
@@ -1374,6 +1539,19 @@ prompt-toolkit = [
     {file = "prompt_toolkit-3.0.8-py3-none-any.whl", hash = "sha256:7debb9a521e0b1ee7d2fe96ee4bd60ef03c6492784de0547337ca4433e46aa63"},
     {file = "prompt_toolkit-3.0.8.tar.gz", hash = "sha256:25c95d2ac813909f813c93fde734b6e44406d1477a9faef7c915ff37d39c0a8c"},
 ]
+psutil = [
+    {file = "psutil-5.7.3-cp27-none-win32.whl", hash = "sha256:1cd6a0c9fb35ece2ccf2d1dd733c1e165b342604c67454fd56a4c12e0a106787"},
+    {file = "psutil-5.7.3-cp27-none-win_amd64.whl", hash = "sha256:e02c31b2990dcd2431f4524b93491941df39f99619b0d312dfe1d4d530b08b4b"},
+    {file = "psutil-5.7.3-cp35-cp35m-win32.whl", hash = "sha256:56c85120fa173a5d2ad1d15a0c6e0ae62b388bfb956bb036ac231fbdaf9e4c22"},
+    {file = "psutil-5.7.3-cp35-cp35m-win_amd64.whl", hash = "sha256:fa38ac15dbf161ab1e941ff4ce39abd64b53fec5ddf60c23290daed2bc7d1157"},
+    {file = "psutil-5.7.3-cp36-cp36m-win32.whl", hash = "sha256:01bc82813fbc3ea304914581954979e637bcc7084e59ac904d870d6eb8bb2bc7"},
+    {file = "psutil-5.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:6a3e1fd2800ca45083d976b5478a2402dd62afdfb719b30ca46cd28bb25a2eb4"},
+    {file = "psutil-5.7.3-cp37-cp37m-win32.whl", hash = "sha256:fbcac492cb082fa38d88587d75feb90785d05d7e12d4565cbf1ecc727aff71b7"},
+    {file = "psutil-5.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:5d9106ff5ec2712e2f659ebbd112967f44e7d33f40ba40530c485cc5904360b8"},
+    {file = "psutil-5.7.3-cp38-cp38-win32.whl", hash = "sha256:ade6af32eb80a536eff162d799e31b7ef92ddcda707c27bbd077238065018df4"},
+    {file = "psutil-5.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:2cb55ef9591b03ef0104bedf67cc4edb38a3edf015cf8cf24007b99cb8497542"},
+    {file = "psutil-5.7.3.tar.gz", hash = "sha256:af73f7bcebdc538eda9cc81d19db1db7bf26f103f91081d780bbacfcb620dee2"},
+]
 psycopg2 = [
     {file = "psycopg2-2.8.6-cp27-cp27m-win32.whl", hash = "sha256:068115e13c70dc5982dfc00c5d70437fe37c014c808acce119b5448361c03725"},
     {file = "psycopg2-2.8.6-cp27-cp27m-win_amd64.whl", hash = "sha256:d160744652e81c80627a909a0e808f3c6653a40af435744de037e3172cf277f5"},
@@ -1407,6 +1585,10 @@ pygraphviz = [
 pylint = [
     {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},
     {file = "pylint-2.6.0.tar.gz", hash = "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ poetry-githooks = "^1.1.2"
 umap-learn = "^0.4.6"
 plotly = "^4.11.0"
 ipython = "^7.18.1"
+memory-profiler = "^0.58.0"
+matplotlib = "^3.3.2"
 
 [tool.isort]
 multi_line_output = 3


### PR DESCRIPTION
Previous causes of high memory usage:
- `parse_ratings.py`: loads the entire set of evaluations into memory before applying operations
- `transform.py`: Pandas memory usage spikes during `read_json` and `explode`

Fixes:
- `parse_ratings.py` now incrementally writes to CSV tables (identical to staged ones except without course_id matching and cross-listing deduplication), with a maximum memory usage of 100MB compared to several GB before
- `transform.py` now loads these tables and no longer requires `read_json` or `explode` to process the evaluations, reducing peak memory usage by a factor of ~5
