### PR TITLE
Computed table nulls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
   "files.watcherExclude": {
     "**/api_output/**": true,
     "**/data/**": true
-  }
+  },
+  "cSpell.words": [
+    "tqdm"
+  ]
 }

--- a/ferry/database/models.py
+++ b/ferry/database/models.py
@@ -286,7 +286,7 @@ class Course(BaseModel):
     )
     average_rating_same_professors_n = Column(
         Integer,
-        comment="""[[computed] Number of courses used to compute
+        comment="""[computed] Number of courses used to compute
         `average_rating_same_professors`""",
     )
 
@@ -297,7 +297,7 @@ class Course(BaseModel):
     )
     average_workload_same_professors_n = Column(
         Integer,
-        comment="""[[computed] Number of courses used to compute
+        comment="""[computed] Number of courses used to compute
         `average_workload_same_professors`""",
     )
 

--- a/ferry/deploy.py
+++ b/ferry/deploy.py
@@ -109,10 +109,10 @@ def search_setup(session):
 
     print("Setting columns to not null if possible")
     table_name = "computed_listing_info_tmp"
-    for (column_name,) in session.execute(
+    for (_, _, column_name) in session.execute(
         # Get the list of columns in the table.
         f"""
-        SELECT *
+        SELECT table_schema, table_name, column_name
         FROM information_schema.columns
         WHERE table_name = '{table_name}';
         """
@@ -121,13 +121,14 @@ def search_setup(session):
             f"""
             SELECT count(*) FROM {table_name} WHERE {column_name} IS NULL ;
             """
-        )[0]
+        ).first()
         if null_count == 0:
             session.execute(
                 f"""
-                ALTER TABLE {table_name} ALTER COLUMN {column_name} SET NOT NULL
+                ALTER TABLE {table_name} ALTER COLUMN {column_name} SET NOT NULL ;
                 """
             )
+            print(f"  {column_name} not null")
 
     print("Swapping in the table")
     with open(f"{config.RESOURCE_DIR}/computed_listing_info_swap.sql") as swap_file:

--- a/ferry/deploy.py
+++ b/ferry/deploy.py
@@ -99,12 +99,40 @@ def course_invariants(session):
 
 def search_setup(session):
     """
-    Set up materialized view and search function
+    Set up an aggregated course information table.
     """
 
-    with open(f"{config.RESOURCE_DIR}/search.sql") as file:
-        sql = file.read()
-    session.execute(sql)
+    print("Creating tmp table")
+    with open(f"{config.RESOURCE_DIR}/computed_listing_info_tmp.sql") as tmp_file:
+        tmp_sql = tmp_file.read()
+        session.execute(tmp_sql)
+
+    print("Setting columns to not null if possible")
+    table_name = "computed_listing_info_tmp"
+    for (column_name,) in session.execute(
+        # Get the list of columns in the table.
+        f"""
+        SELECT *
+        FROM information_schema.columns
+        WHERE table_name = '{table_name}';
+        """
+    ):
+        (null_count,) = session.execute(
+            f"""
+            SELECT count(*) FROM {table_name} WHERE {column_name} IS NULL ;
+            """
+        )[0]
+        if null_count == 0:
+            session.execute(
+                f"""
+                ALTER TABLE {table_name} ALTER COLUMN {column_name} SET NOT NULL
+                """
+            )
+
+    print("Swapping in the table")
+    with open(f"{config.RESOURCE_DIR}/computed_listing_info_swap.sql") as swap_file:
+        swap_sql = swap_file.read()
+        session.execute(swap_sql)
 
 
 if __name__ == "__main__":
@@ -164,10 +192,8 @@ if __name__ == "__main__":
     # Check invariants on new tables
     # ------------------------------
 
-    # check invariants
     print("\n[Checking table invariants]")
 
-    # check invariants
     args = parser.parse_args()
     if args.items:
         items = [_match(name) for name in args.items]
@@ -199,7 +225,7 @@ if __name__ == "__main__":
     replace = conn.begin()
     conn.execute("SET CONSTRAINTS ALL DEFERRED;")
 
-    # drop and update tables in reverse dependnecy order
+    # drop and update tables in reverse dependency order
     for table in target_tables:
 
         print(f"Updating table {table}")
@@ -278,18 +304,8 @@ if __name__ == "__main__":
     # Print row counts for each table.
     tqdm.write("\n[Table Statistics]")
     with database.session_scope(database.Session) as db_session:
-        # Via https://stackoverflow.om/a/2611745/5004662.
-        SUMMARY_SQL = """
-        select table_schema,
-            table_name,
-            (xpath('/row/cnt/text()', xml_count))[1]::text::int as row_count
-        from (
-        select table_name, table_schema,
-                query_to_xml(format('select count(*) as cnt from %I.%I', table_schema, table_name), false, true, '') as xml_count
-        from information_schema.tables
-        where table_schema = 'public' --<< change here for the schema you want
-        ) t
-        """
+        with open(f"{config.RESOURCE_DIR}/table_sizes.sql") as file:
+            SUMMARY_SQL = file.read()
 
         result = db_session.execute(SUMMARY_SQL)
         for table_counts in result:

--- a/resources/computed_listing_info_swap.sql
+++ b/resources/computed_listing_info_swap.sql
@@ -1,0 +1,24 @@
+-- This script swaps the temporary computed listing info table into
+-- the final name, and then adds a number of indexes.
+
+BEGIN TRANSACTION;
+
+-- Swap the new table in.
+DROP TABLE IF EXISTS computed_listing_info CASCADE;
+ALTER TABLE computed_listing_info_tmp
+    RENAME TO computed_listing_info;
+
+-- Create an index for the important columns.
+ALTER TABLE computed_listing_info
+    ADD FOREIGN KEY (course_id) REFERENCES courses (course_id);
+ALTER TABLE computed_listing_info
+    ADD FOREIGN KEY (listing_id) REFERENCES listings (listing_id);
+CREATE INDEX idx_computed_listing_course_id ON computed_listing_info (course_id);
+CREATE UNIQUE INDEX idx_computed_listing_listing_id ON computed_listing_info (listing_id);
+CREATE INDEX idx_computed_listing_order_def ON computed_listing_info (course_code ASC, course_id ASC);
+CREATE INDEX idx_computed_listing_skills ON computed_listing_info USING gin (skills);
+CREATE INDEX idx_computed_listing_areas ON computed_listing_info USING gin (areas);
+CREATE INDEX idx_computed_listing_season ON computed_listing_info (season_code);
+CREATE INDEX idx_computed_listing_season_hash ON computed_listing_info USING hash (season_code);
+
+COMMIT;

--- a/resources/table_sizes.sql
+++ b/resources/table_sizes.sql
@@ -1,0 +1,12 @@
+-- Via https://stackoverflow.com/a/2611745/5004662.
+select table_schema,
+       table_name,
+       (xpath('/row/cnt/text()', xml_count))[1]::text::int as row_count
+from (
+         select table_name,
+                table_schema,
+                query_to_xml(format('select count(*) as cnt from %I.%I', table_schema, table_name), false, true,
+                             '') as xml_count
+         from information_schema.tables
+         where table_schema = 'public' --<< change here for the schema you want
+     ) t


### PR DESCRIPTION
When possible, it sets columns in the computed_listing_info to not null. This makes the graphql interface more correct, which helps with strongly typing the frontend. 