### PR TITLE
Update evals fetching

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://code.visualstudio.com/docs/remote/create-dev-container#_extend-your-docker-compose-file-for-development
+{
+	"name": "ferry-image",
+	// path inside the container to init
+	"workspaceFolder": "/ferry",
+	// list of compose files to use (later ones overwrite earlier ones)
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+		"../docker-compose.dev.yml"
+	],
+	// service to enter into
+	"service": "ferry",
+	"shutdownAction": "stopCompose",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		5432
+	],
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# see https://stackoverflow.com/questions/53835198/integrating-python-poetry-with-docker
+FROM python:3.8-slim-buster as base
+
+WORKDIR /app
+ 
+FROM base as final
+
+# install dependencies
+RUN apt-get update
+# low-level stuff
+RUN apt-get -y install gcc g++ musl-dev libffi-dev libpq-dev
+# for pytables
+RUN apt-get -y install libhdf5-dev python-tables
+# for network visualization
+RUN apt-get -y install graphviz libgraphviz-dev
+
+# Install poetry:
+RUN python -m pip install poetry
+
+# Copy everything
+COPY . .

--- a/ferry/config.py
+++ b/ferry/config.py
@@ -28,8 +28,8 @@ CAS_CREDENTIAL_NETID: Callable[[Any], str] = functools.lru_cache(
     lambda: input("Yale NetId: ")
 )
 CAS_CREDENTIAL_PASSWORD: Callable[[Any], str] = functools.lru_cache(getpass.getpass)
-CAS_COOKIE_CASTGC: Callable[[Any], str] = functools.lru_cache(
-    lambda: input("CASTGC Cookie: ")
+CAS_COOKIE_TGC: Callable[[Any], str] = functools.lru_cache(
+    lambda: input("TGC Cookie: ")
 )
 
 

--- a/ferry/crawler/fetch_ratings.py
+++ b/ferry/crawler/fetch_ratings.py
@@ -11,8 +11,9 @@ following steps:
 """
 import argparse
 import datetime
+from multiprocessing import Pool
 from os.path import isfile
-from typing import Union
+from typing import Tuple, Union
 
 import diskcache
 import requests
@@ -157,31 +158,47 @@ for season_code in seasons:
 session = create_session()
 print("Cookies: ", session.cookies.get_dict())
 
-for season_code, crn in tqdm(queue):
-    course_unique_id = f"{season_code}-{crn}"
+
+def handle_course_evals(function_args: Tuple[str, str]):
+
+    """
+    Main course evaluations fetching function, called by process pool worker.
+
+    Parameters
+    ----------
+    function_args:
+        Tuple of (handler_season_code, )
+    """
+
+    course_season_code, course_crn = function_args
+
+    course_unique_id = f"{course_season_code}-{course_crn}"
     output_path = f"{config.DATA_DIR}/course_evals/{course_unique_id}.json"
-
-    if isfile(output_path) and not args.force:
-        # tqdm.write(f"Skipping course {course_unique_id} - already exists")
-        continue
-
-    if season_code[-2:] != "02" and not is_yale_college(season_code, crn):
-        # tqdm.write("skipping - not in yale college")
-        continue
 
     tqdm.write(f"Working on {course_unique_id} ... ")
     tqdm.write("                            ", end="")
 
+    if isfile(output_path) and not args.force:
+        tqdm.write(f"Skipping course {course_unique_id} - already exists")
+        return
+
+    # if course is not a summer course and not a Yale college one
+    if course_season_code[-2:] != "02" and not is_yale_college(
+        course_season_code, course_crn
+    ):
+        tqdm.write("Skipping - not in Yale College")
+        return
+
     try:
-        session = create_session()
-        course_eval = fetch_course_eval(session, crn, season_code)
+        handler_session = create_session()
+        course_eval = fetch_course_eval(handler_session, course_crn, course_season_code)
 
-        with open(output_path, "w") as f:
-            f.write(ujson.dumps(course_eval, indent=4))
+        with open(output_path, "w") as file:
+            ujson.dump(course_eval, file, indent=4)
 
-        tqdm.write("dumped in JSON")
+        tqdm.write("Dumped in JSON")
     # except SeasonMissingEvalsError:
-    #     tqdm.write(f"Skipping season {season_code} - missing evals")
+    #     tqdm.write(f"Skipping season {course_season_code} - missing evals")
     # except CrawlerError:
     #     tqdm.write(f"skipped - missing evals")
 
@@ -189,4 +206,15 @@ for season_code, crn in tqdm(queue):
     except Exception as error:
 
         # traceback.print_exc()
-        tqdm.write(f"skipped - unknown error {error}")
+        tqdm.write(f"Skipped - unknown error {error}")
+
+
+# fetch ratings in parallel
+pool = Pool(processes=16)
+
+# use imap_unordered to report to tqdm
+with tqdm(total=len(queue), desc="Subjects retrieved") as pbar:
+    for i, result in enumerate(pool.imap_unordered(handle_course_evals, queue)):
+        pbar.update()
+
+pool.terminate()

--- a/ferry/crawler/fetch_ratings.py
+++ b/ferry/crawler/fetch_ratings.py
@@ -37,8 +37,8 @@ class FetchRatingsError(Exception):
 EXCLUDE_SEASONS = [
     "201701",  # too old
     "201702",  # too old
+    "201703",  # too old
     "202001",  # not evaluated because of COVID
-    "202003",  # too new
     "202101",  # too new
 ]
 

--- a/ferry/includes/cas.py
+++ b/ferry/includes/cas.py
@@ -29,13 +29,17 @@ def _create_session_from_cookie(tgc: str) -> requests.Session:
     # Set user-agent for requests to work
     session.headers.update(
         {
-            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0"
+            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0"  # pylint: disable=line-too-long
         }
     )
 
     # Manually set cookie.
     cookie = requests.cookies.create_cookie(
-        domain="secure.its.yale.edu", name="TGC", value=tgc, path="/cas/", secure=True,
+        domain="secure.its.yale.edu",
+        name="TGC",
+        value=tgc,
+        path="/cas/",
+        secure=True,
     )
     session.cookies.set_cookie(cookie)
 

--- a/ferry/includes/cas.py
+++ b/ferry/includes/cas.py
@@ -17,22 +17,25 @@ def _create_session_from_credentials(net_id: str, password: str) -> requests.Ses
     )
 
     # Verify that it worked.
-    if "CASTGC" not in session.cookies.get_dict():
+    if "TGC" not in session.cookies.get_dict():
         raise NotImplementedError("cannot handle 2-factor authentication")
 
     return session
 
 
-def _create_session_from_cookie(castgc: str) -> requests.Session:
+def _create_session_from_cookie(tgc: str) -> requests.Session:
     session = requests.Session()
+
+    # Set user-agent for requests to work
+    session.headers.update(
+        {
+            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0"
+        }
+    )
 
     # Manually set cookie.
     cookie = requests.cookies.create_cookie(
-        domain="secure.its.yale.edu",
-        name="CASTGC",
-        value=castgc,
-        path="/cas/",
-        secure=True,
+        domain="secure.its.yale.edu", name="TGC", value=tgc, path="/cas/", secure=True,
     )
     session.cookies.set_cookie(cookie)
 
@@ -45,8 +48,8 @@ def create_session() -> requests.Session:
     """
 
     if config.CAS_USE_COOKIE:
-        castgc = resolve_potentially_callable(config.CAS_COOKIE_CASTGC)
-        return _create_session_from_cookie(castgc)
+        tgc = resolve_potentially_callable(config.CAS_COOKIE_TGC)
+        return _create_session_from_cookie(tgc)
 
     net_id = resolve_potentially_callable(config.CAS_CREDENTIAL_NETID)
     password = resolve_potentially_callable(config.CAS_CREDENTIAL_PASSWORD)


### PR DESCRIPTION
- Changes cookie-based CAS authentication to use the TGC cookie instead of CASTGC, and also adds a required user-agent
- Parallelizes evaluations fetching (Fall 2020 now takes 8 minutes vs. 2 hours)
- Adds a Dockerfile for complete dependency support, and a devcontainer config for integrating with VSCode